### PR TITLE
cleanup tests and use better `up` init logic

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -11,21 +11,20 @@ import {
     getTableland,
     getSafe,
     renderPath,
-    loadSpecTestData
+    loadSpecTestData,
+    getAccounts
 } from './utils';
 
 const __dirname = path.resolve(path.dirname(''));
 
 // These tests take a bit longer than normal since we are usually waiting for blocks to finalize etc...
 jest.setTimeout(25000);
+const accounts = getAccounts();
 
+// NOTE: these tests require the a local Tableland is already running
 describe('Validator, Chain, and SDK work end to end', function () {
-    // NOTE: these tests require the a local Tableland is already running
-
     test('Create a table that can be read from', async function () {
-        const wallet = new Wallet('0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d' /* Hardhat #1 */);
-        const provider = new providers.JsonRpcProvider('http://localhost:8545');
-        const signer = wallet.connect(provider);
+        const signer = accounts[1];
 
         const tableland = await getTableland(signer);
 
@@ -40,9 +39,7 @@ describe('Validator, Chain, and SDK work end to end', function () {
     });
 
     test('Create a table that can be written to', async function () {
-        const wallet = new Wallet('0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d' /* Hardhat #1 */);
-        const provider = new providers.JsonRpcProvider('http://localhost:8545');
-        const signer = wallet.connect(provider);
+        const signer = accounts[1];
 
         const tableland = await getTableland(signer);
 
@@ -61,9 +58,7 @@ describe('Validator, Chain, and SDK work end to end', function () {
     });
 
     test('Table cannot be written to unless caller is allowed', async function () {
-        const wallet = new Wallet('0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d' /* Hardhat #1 */);
-        const provider = new providers.JsonRpcProvider('http://localhost:8545');
-        const signer = wallet.connect(provider);
+        const signer = accounts[1];
 
         const tableland = await getTableland(signer);
 
@@ -76,10 +71,7 @@ describe('Validator, Chain, and SDK work end to end', function () {
         const data = await tableland.read(`SELECT * FROM ${queryableName};`);
         await expect(data.rows).toEqual([]);
 
-        const wallet2 = new Wallet('0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a' /* Hardhat #2 */);
-        const provider2 = new providers.JsonRpcProvider('http://localhost:8545');
-        const signer2 = wallet2.connect(provider2);
-
+        const signer2 = accounts[2];
         const tableland2 = await getTableland(signer2);
 
         const writeRes = await tableland2.write(`INSERT INTO ${queryableName} (keyy, val) VALUES ('tree', 'aspen')`);
@@ -91,9 +83,7 @@ describe('Validator, Chain, and SDK work end to end', function () {
     });
 
     test('Create a table can have a row deleted', async function () {
-        const wallet = new Wallet('0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d' /* Hardhat #1 */);
-        const provider = new providers.JsonRpcProvider('http://localhost:8545');
-        const signer = wallet.connect(provider);
+        const signer = accounts[1];
 
         const tableland = await getTableland(signer);
 
@@ -123,9 +113,7 @@ describe('Validator, Chain, and SDK work end to end', function () {
     }, 30000);
 
     test('List an account\'s tables', async function () {
-        const wallet = new Wallet('0x701b615bbdfb9de65240bc28bd21bbc0d996645a3dd57e7b12bc2bdf6f192c82' /* Hardhat #11 */);
-        const provider = new providers.JsonRpcProvider('http://localhost:8545');
-        const signer = wallet.connect(provider);
+        const signer = accounts[1];
 
         const tableland = await getTableland(signer);
 
@@ -145,9 +133,7 @@ describe('Validator, Chain, and SDK work end to end', function () {
     });
 
     test('write to a table without using the relay', async function () {
-        const wallet = new Wallet('0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d' /* Hardhat #1 */);
-        const provider = new providers.JsonRpcProvider('http://localhost:8545');
-        const signer = wallet.connect(provider);
+        const signer = accounts[1];
 
         const tableland = await getTableland(signer, {rpcRelay: false});
 
@@ -166,9 +152,7 @@ describe('Validator, Chain, and SDK work end to end', function () {
     });
 
     test('write without relay statement validates table name prefix', async function () {
-        const wallet = new Wallet('0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d' /* Hardhat #1 */);
-        const provider = new providers.JsonRpcProvider('http://localhost:8545');
-        const signer = wallet.connect(provider);
+        const signer = accounts[1];
 
         const tableland = await getTableland(signer, {rpcRelay: false});
 
@@ -190,9 +174,7 @@ describe('Validator, Chain, and SDK work end to end', function () {
     });
 
     test('write without relay statement validates table ID', async function () {
-        const wallet = new Wallet('0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d' /* Hardhat #1 */);
-        const provider = new providers.JsonRpcProvider('http://localhost:8545');
-        const signer = wallet.connect(provider);
+        const signer = accounts[1];
 
         const tableland = await getTableland(signer, {rpcRelay: false});
 
@@ -210,9 +192,7 @@ describe('Validator, Chain, and SDK work end to end', function () {
     });
 
     test('set controller without relay', async function () {
-        const wallet = new Wallet('0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d' /* Hardhat #1 */);
-        const provider = new providers.JsonRpcProvider('http://localhost:8545');
-        const signer = wallet.connect(provider);
+        const signer = accounts[1];
 
         const tableland = await getTableland(signer, { rpcRelay: false });
 
@@ -230,9 +210,7 @@ describe('Validator, Chain, and SDK work end to end', function () {
     });
 
     test('set controller with relay', async function () {
-        const wallet = new Wallet('0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d' /* Hardhat #1 */);
-        const provider = new providers.JsonRpcProvider('http://localhost:8545');
-        const signer = wallet.connect(provider);
+        const signer = accounts[1];
 
         const tableland = await getTableland(signer, {
             rpcRelay: true /* this is default `true`, just being explicit */
@@ -252,9 +230,7 @@ describe('Validator, Chain, and SDK work end to end', function () {
     });
 
     test('get controller returns an address', async function () {
-        const wallet = new Wallet('0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d' /* Hardhat #1 */);
-        const provider = new providers.JsonRpcProvider('http://localhost:8545');
-        const signer = wallet.connect(provider);
+        const signer = accounts[1];
 
         const tableland = await getTableland(signer);
 
@@ -277,9 +253,7 @@ describe('Validator, Chain, and SDK work end to end', function () {
     });
 
     test('lock controller without relay returns a transaction hash', async function () {
-        const wallet = new Wallet('0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d' /* Hardhat #1 */);
-        const provider = new providers.JsonRpcProvider('http://localhost:8545');
-        const signer = wallet.connect(provider);
+        const signer = accounts[1];
 
         const tableland = await getTableland(signer, { rpcRelay: false });
 
@@ -311,14 +285,12 @@ describe('Validator gateway server', function () {
 
         // TODO: split openapi spec tests and js tests into different files and npm commands,
         //       then `npm test` can run everything.
-        const wallet0 = new Wallet('0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80' /* Hardhat #0 */);
-        const signer0 = wallet0.connect(provider);
+        const signer0 = accounts[0];
         const tableland0 = await getTableland(signer0);
         await tableland0.siwe();
 
         // We can't use the Validator's Wallet to create tables because the Validator's nonce tracking will get out of sync
-        const wallet1 = new Wallet('0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d' /* Hardhat #1 */);
-        const signer1 = wallet1.connect(provider);
+        const signer1 = accounts[1];
         const tableland1 = await getTableland(signer1);
 
         const prefix = 'test_transaction';

--- a/test/utils.js
+++ b/test/utils.js
@@ -206,4 +206,37 @@ export const loadSpecTestData = function (specPath, renderData) {
     }
 
     return tests;
+};
+
+export const getAccounts = function () {
+    return [
+        getWallet('0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80'),
+        getWallet('0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d'),
+        getWallet('0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a'),
+        getWallet('0x7c852118294e51e653712a81e05800f419141751be58f605c371e15141b007a6'),
+        getWallet('0x47e179ec197488593b187f80a00eb0da91f1b9d0b13f8733639f19c30a34926a'),
+        getWallet('0x8b3a350cf5c34c9194ca85829a2df0ec3153be0318b5e2d3348e872092edffba'),
+        getWallet('0x92db14e403b83dfe3df233f83dfa3a0d7096f21ca9b0d6d6b8d88b2b4ec1564e'),
+        getWallet('0x4bbbf85ce3377467afe5d46f804f221813b2bb87f24d81f60f1fcdbf7cbf4356'),
+        getWallet('0xdbda1821b80551c9d65939329250298aa3472ba22feea921c0cf5d620ea67b97'),
+        getWallet('0x2a871d0798f97d79848a013d4936a73bf4cc922c825d33c1cf7073dff6d409c6'),
+        getWallet('0xf214f2b2cd398c806f84e317254e0f0b801d0643303237d97a22a48e01628897'),
+        getWallet('0x701b615bbdfb9de65240bc28bd21bbc0d996645a3dd57e7b12bc2bdf6f192c82'),
+        getWallet('0xa267530f49f8280200edf313ee7af6b827f2a8bce2897751d06a843f644967b1'),
+        getWallet('0x47c99abed3324a2707c28affff1267e45918ec8c3f20b8aa892e8b065d2942dd'),
+        getWallet('0xc526ee95bf44d8fc405a158bb884d9d1238d99f0612e9f33d006bb0789009aaa'),
+        getWallet('0x8166f546bab6da521a8369cab06c5d2b9e46670292d85c875ee9ec20e84ffb61'),
+        getWallet('0xea6c44ac03bff858b476bba40716402b03e41b8e97e276d1baec7c37d42484a0'),
+        getWallet('0x689af8efa8c651a91ad287602527f3af2fe9f6501a7ac4b061667b5a93e037fd'),
+        getWallet('0xde9be858da4a475276426320d5e9262ecfc3ba460bfac56360bfa6c4c28b4ee0'),
+        getWallet('0xdf57089febbacf7ba0bc227dafbffa9fc08a93fdc68e1e42411a14efcf23656e')
+    ];
+};
+
+const getWallet = function (pk) {
+    const wallet = new Wallet(pk);
+    const provider = new providers.JsonRpcProvider('http://localhost:8545');
+    const signer = wallet.connect(provider);
+
+    return signer;
 }


### PR DESCRIPTION
Two pieces of cleanup here:
 - refactor the use of hard coded wallet key strings to utils
 - when initializing the local Tableland stack, wait until processes are ready instead of just waiting an arbitrary amount of time