### PR TITLE
fix #49 and make build output consistent with the cli

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@ tmp
 node_modules
 .env
 .envrc
-bin/
+dist/

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "clean": "rm -rf bin/*",
     "build:esm": "tsc -p tsconfig.json",
     "build:cjs": "tsc -p tsconfig.cjs.json",
-    "build": "npm run clean && npm run build:esm && npm run build:cjs",
+    "build": "npm run clean && npm run build:esm && npm run build:cjs && chmod +x bin/up.js",
     "up": "node bin/up.js --validator ../go-tableland --registry ../evm-tableland"
   },
   "bin": {

--- a/package.json
+++ b/package.json
@@ -15,18 +15,18 @@
   "engines": {
     "node": ">=14.0.0"
   },
-  "main": "./bin/cjs/main.js",
-  "module": "./bin/main.js",
-  "types": "./bin/main.d.ts",
+  "main": "./dist/cjs/main.js",
+  "module": "./dist/main.js",
+  "types": "./dist/main.d.ts",
   "exports": {
     ".": {
-      "require": "./bin/cjs/main.js",
-      "import": "./bin/main.js",
-      "default": "./bin/main.js"
+      "require": "./dist/cjs/main.js",
+      "import": "./dist/main.js",
+      "default": "./dist/main.js"
     }
   },
   "files": [
-    "bin/*",
+    "dist/*",
     "src/*"
   ],
   "scripts": {
@@ -35,14 +35,14 @@
     "prepublishOnly": "npm run build",
     "prettier": "prettier '**/*.{ts,json,md}' --check",
     "prettier:fix": "npm run prettier -- --write",
-    "clean": "rm -rf bin/*",
+    "clean": "rm -rf dist/*",
     "build:esm": "tsc -p tsconfig.json",
     "build:cjs": "tsc -p tsconfig.cjs.json",
-    "build": "npm run clean && npm run build:esm && npm run build:cjs && chmod +x bin/up.js",
-    "up": "node bin/up.js --validator ../go-tableland --registry ../evm-tableland"
+    "build": "npm run clean && npm run build:esm && npm run build:cjs && chmod +x dist/up.js",
+    "up": "node dist/up.js --validator ../go-tableland --registry ../evm-tableland"
   },
   "bin": {
-    "local-tableland": "bin/up.js"
+    "local-tableland": "dist/up.js"
   },
   "type": "module",
   "dependencies": {

--- a/src/up.ts
+++ b/src/up.ts
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 import yargs from "yargs/yargs";
 import { hideBin } from "yargs/helpers";
 import { LocalTableland } from "./main.js";

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -6,8 +6,8 @@ import {
   testHttpResponse,
   getTableland,
   loadSpecTestData,
-} from "./utils";
-import { getAccounts } from "../src/utils";
+} from "./util";
+import { getAccounts } from "../src/util";
 
 const __dirname = path.resolve(path.dirname(""));
 // TODO: we were using these tests to check the validator's OAS spec via

--- a/test/e2e.test.js
+++ b/test/e2e.test.js
@@ -1,8 +1,8 @@
 import { spawnSync } from "node:child_process";
 import { join } from "node:path";
 import path from "path";
-import { getTableland } from "./utils";
-import { getAccounts } from "../src/utils";
+import { getTableland } from "./util";
+import { getAccounts } from "../src/util";
 
 const __dirname = path.resolve(path.dirname(""));
 // TODO: we were using these tests to check the validator's OAS spec via

--- a/test/util.js
+++ b/test/util.js
@@ -1,6 +1,6 @@
 import fs from "fs";
 import yaml from "js-yaml";
-import { connect } from "@tableland/sdk";
+import { connect, Connection } from "@tableland/sdk";
 
 export const HOST = "http://localhost:8080";
 

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "es2015",
-    "outDir": "./bin/cjs/",
+    "outDir": "./dist/cjs/",
     "lib": ["ES6"],
     "isolatedModules": true,
     "module": "commonjs",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,7 @@
     "allowSyntheticDefaultImports": true,
     "experimentalDecorators": true,
     "sourceMap": true,
-    "outDir": "./bin/",
+    "outDir": "./dist/",
     "types": ["node"],
     "lib": ["ES6"]
   },


### PR DESCRIPTION
This changes the name of the build out from bin to dist to match js-tableland-cli.  Also fixes the issue where the published runnable was not working via npx