### PR TITLE
expose premade tableland connections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,7 @@ validator/backups
 cache
 artifacts
 
+#IDE
+.vscode
+.idea
+

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,7 +13,7 @@ import {
   Config,
   pipeNamedSubprocess,
   waitForReady,
-  getAccounts,
+  getConnections,
   logSync,
 } from "./util.js";
 
@@ -219,4 +219,4 @@ class LocalTableland {
   }
 }
 
-export { LocalTableland, getAccounts };
+export { LocalTableland, getConnections };

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,7 +13,8 @@ import {
   Config,
   pipeNamedSubprocess,
   waitForReady,
-  getConnections,
+  getAccounts,
+  getConnection,
   logSync,
 } from "./util.js";
 
@@ -219,4 +220,4 @@ class LocalTableland {
   }
 }
 
-export { LocalTableland, getConnections };
+export { LocalTableland, getAccounts, getConnection };

--- a/src/util.ts
+++ b/src/util.ts
@@ -3,7 +3,7 @@ import { EventEmitter } from "node:events";
 import { Readable } from "node:stream";
 import { ChildProcess, SpawnSyncReturns } from "node:child_process";
 import { getDefaultProvider, Wallet } from "ethers";
-import { connect, Connection } from "@tableland/sdk";
+import { connect, Connection, ConnectOptions } from "@tableland/sdk";
 import { chalk } from "./chalk.js";
 
 // NOTE: We are creating this file in the prebuild.sh script so that we can support cjs and esm
@@ -263,14 +263,16 @@ const hardhatAccounts = [
   "df57089febbacf7ba0bc227dafbffa9fc08a93fdc68e1e42411a14efcf23656e",
 ];
 
-export const getConnection = function (account: Wallet): Connection {
-  return connect({ signer: account, chain: "local-tableland" });
+export const getConnection = function (
+  account: Wallet,
+  options: ConnectOptions = {}
+): Connection {
+  return connect({ signer: account, chain: "local-tableland", ...options });
 };
 
 export const getAccounts = function (): Wallet[] {
-  // explicitly use 127.0.0.1
-  // TODO: not sure what's going on, but node v18 seems to resolve
-  //       localhost differently in different environments
+  // explicitly use IPv4 127.0.0.1
+  // node resolves localhost to IPv4 or IPv6 depending on env
   return hardhatAccounts.map((account) => {
     const wallet = new Wallet(account);
     return wallet.connect(getDefaultProvider("http://127.0.0.1:8545"));

--- a/src/util.ts
+++ b/src/util.ts
@@ -2,7 +2,8 @@ import { isAbsolute, join, resolve } from "node:path";
 import { EventEmitter } from "node:events";
 import { Readable } from "node:stream";
 import { ChildProcess, SpawnSyncReturns } from "node:child_process";
-import { ethers } from "ethers";
+import { providers, Wallet } from "ethers";
+import { connect, Connection } from "@tableland/sdk";
 import { chalk } from "./chalk.js";
 
 // NOTE: We are creating this file in the prebuild.sh script so that we can support cjs and esm
@@ -239,92 +240,38 @@ export const defaultRegistryDir = async function () {
   return resolve(_dirname, "..", "..", "registry");
 };
 
-export const getAccounts = function (): ethers.Wallet[] {
-  // explicitly use 127.0.0.1
-  // TODO: not sure what's going on, but node v18 seems to resolve
-  //       localhost differently in different environments
-  const defaultProvider = ethers.getDefaultProvider("http://127.0.0.1:8545");
+export const getConnections = function (): Connection[] {
+  const conns: Connection[] = [];
 
-  return [
-    new ethers.Wallet(
-      "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
-      defaultProvider
-    ),
-    new ethers.Wallet(
-      "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d",
-      defaultProvider
-    ),
-    new ethers.Wallet(
-      "0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a",
-      defaultProvider
-    ),
-    new ethers.Wallet(
-      "0x7c852118294e51e653712a81e05800f419141751be58f605c371e15141b007a6",
-      defaultProvider
-    ),
-    new ethers.Wallet(
-      "0x47e179ec197488593b187f80a00eb0da91f1b9d0b13f8733639f19c30a34926a",
-      defaultProvider
-    ),
-    new ethers.Wallet(
-      "0x8b3a350cf5c34c9194ca85829a2df0ec3153be0318b5e2d3348e872092edffba",
-      defaultProvider
-    ),
-    new ethers.Wallet(
-      "0x92db14e403b83dfe3df233f83dfa3a0d7096f21ca9b0d6d6b8d88b2b4ec1564e",
-      defaultProvider
-    ),
-    new ethers.Wallet(
-      "0x4bbbf85ce3377467afe5d46f804f221813b2bb87f24d81f60f1fcdbf7cbf4356",
-      defaultProvider
-    ),
-    new ethers.Wallet(
-      "0xdbda1821b80551c9d65939329250298aa3472ba22feea921c0cf5d620ea67b97",
-      defaultProvider
-    ),
-    new ethers.Wallet(
-      "0x2a871d0798f97d79848a013d4936a73bf4cc922c825d33c1cf7073dff6d409c6",
-      defaultProvider
-    ),
-    new ethers.Wallet(
-      "0xf214f2b2cd398c806f84e317254e0f0b801d0643303237d97a22a48e01628897",
-      defaultProvider
-    ),
-    new ethers.Wallet(
-      "0x701b615bbdfb9de65240bc28bd21bbc0d996645a3dd57e7b12bc2bdf6f192c82",
-      defaultProvider
-    ),
-    new ethers.Wallet(
-      "0xa267530f49f8280200edf313ee7af6b827f2a8bce2897751d06a843f644967b1",
-      defaultProvider
-    ),
-    new ethers.Wallet(
-      "0x47c99abed3324a2707c28affff1267e45918ec8c3f20b8aa892e8b065d2942dd",
-      defaultProvider
-    ),
-    new ethers.Wallet(
-      "0xc526ee95bf44d8fc405a158bb884d9d1238d99f0612e9f33d006bb0789009aaa",
-      defaultProvider
-    ),
-    new ethers.Wallet(
-      "0x8166f546bab6da521a8369cab06c5d2b9e46670292d85c875ee9ec20e84ffb61",
-      defaultProvider
-    ),
-    new ethers.Wallet(
-      "0xea6c44ac03bff858b476bba40716402b03e41b8e97e276d1baec7c37d42484a0",
-      defaultProvider
-    ),
-    new ethers.Wallet(
-      "0x689af8efa8c651a91ad287602527f3af2fe9f6501a7ac4b061667b5a93e037fd",
-      defaultProvider
-    ),
-    new ethers.Wallet(
-      "0xde9be858da4a475276426320d5e9262ecfc3ba460bfac56360bfa6c4c28b4ee0",
-      defaultProvider
-    ),
-    new ethers.Wallet(
-      "0xdf57089febbacf7ba0bc227dafbffa9fc08a93fdc68e1e42411a14efcf23656e",
-      defaultProvider
-    ),
-  ];
+  hardhatAccounts.forEach((account) => {
+    const wallet = new Wallet(account);
+    const provider = new providers.JsonRpcProvider("http://127.0.0.1:8545");
+    const signer = wallet.connect(provider);
+    conns.push(connect({ signer, chain: "local-tableland" }));
+  });
+
+  return conns;
 };
+
+const hardhatAccounts = [
+  "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
+  "59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d",
+  "5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a",
+  "7c852118294e51e653712a81e05800f419141751be58f605c371e15141b007a6",
+  "47e179ec197488593b187f80a00eb0da91f1b9d0b13f8733639f19c30a34926a",
+  "8b3a350cf5c34c9194ca85829a2df0ec3153be0318b5e2d3348e872092edffba",
+  "92db14e403b83dfe3df233f83dfa3a0d7096f21ca9b0d6d6b8d88b2b4ec1564e",
+  "4bbbf85ce3377467afe5d46f804f221813b2bb87f24d81f60f1fcdbf7cbf4356",
+  "dbda1821b80551c9d65939329250298aa3472ba22feea921c0cf5d620ea67b97",
+  "2a871d0798f97d79848a013d4936a73bf4cc922c825d33c1cf7073dff6d409c6",
+  "f214f2b2cd398c806f84e317254e0f0b801d0643303237d97a22a48e01628897",
+  "701b615bbdfb9de65240bc28bd21bbc0d996645a3dd57e7b12bc2bdf6f192c82",
+  "a267530f49f8280200edf313ee7af6b827f2a8bce2897751d06a843f644967b1",
+  "47c99abed3324a2707c28affff1267e45918ec8c3f20b8aa892e8b065d2942dd",
+  "c526ee95bf44d8fc405a158bb884d9d1238d99f0612e9f33d006bb0789009aaa",
+  "8166f546bab6da521a8369cab06c5d2b9e46670292d85c875ee9ec20e84ffb61",
+  "ea6c44ac03bff858b476bba40716402b03e41b8e97e276d1baec7c37d42484a0",
+  "689af8efa8c651a91ad287602527f3af2fe9f6501a7ac4b061667b5a93e037fd",
+  "de9be858da4a475276426320d5e9262ecfc3ba460bfac56360bfa6c4c28b4ee0",
+  "df57089febbacf7ba0bc227dafbffa9fc08a93fdc68e1e42411a14efcf23656e",
+];

--- a/src/util.ts
+++ b/src/util.ts
@@ -3,7 +3,7 @@ import { EventEmitter } from "node:events";
 import { Readable } from "node:stream";
 import { ChildProcess, SpawnSyncReturns } from "node:child_process";
 import { getDefaultProvider, Wallet } from "ethers";
-import { connect, Connection, ConnectOptions } from "@tableland/sdk";
+import { connect, Connection } from "@tableland/sdk";
 import { chalk } from "./chalk.js";
 
 // NOTE: We are creating this file in the prebuild.sh script so that we can support cjs and esm
@@ -263,11 +263,8 @@ const hardhatAccounts = [
   "df57089febbacf7ba0bc227dafbffa9fc08a93fdc68e1e42411a14efcf23656e",
 ];
 
-export const getConnection = function (
-  account: Wallet,
-  options: ConnectOptions = {}
-): Connection {
-  return connect({ signer: account, chain: "local-tableland", ...options });
+export const getConnection = function (account: Wallet): Connection {
+  return connect({ signer: account, chain: "local-tableland" });
 };
 
 export const getAccounts = function (): Wallet[] {

--- a/test/e2e.test.mjs
+++ b/test/e2e.test.mjs
@@ -1,4 +1,5 @@
 import chai from "chai";
+import { connect } from "@tableland/sdk";
 import { getAccounts, getConnection } from "../dist/esm/util.js";
 import { LocalTableland } from "../dist/esm/main.js";
 
@@ -346,7 +347,11 @@ describe("Validator, Chain, and SDK work end to end", function () {
     const signer = accounts[1];
 
     // Note: options can be removed when rpcRelay is removed
-    const tableland = getConnection(signer, { rpcRelay: false });
+    const tableland = connect({
+      signer,
+      chain: "local-tableland",
+      rpcRelay: false,
+    });
 
     const prefix = "test_direct_write";
     const { tableId } = await tableland.create("keyy TEXT, val TEXT", {
@@ -369,8 +374,12 @@ describe("Validator, Chain, and SDK work end to end", function () {
   it("write without relay statement validates table name prefix", async function () {
     const signer = accounts[1];
 
-    // Note: options can be removed when rpcRelay is removed
-    const tableland = getConnection(signer, { rpcRelay: false });
+    // Note: use `getConnection` when rpcRelay is removed
+    const tableland = connect({
+      signer,
+      chain: "local-tableland",
+      rpcRelay: false,
+    });
 
     const prefix = "test_direct_invalid_write";
     await tableland.create("keyy TEXT, val TEXT", { prefix });
@@ -398,8 +407,12 @@ describe("Validator, Chain, and SDK work end to end", function () {
   it("write without relay statement validates table ID", async function () {
     const signer = accounts[1];
 
-    // Note: options can be removed when rpcRelay is removed
-    const tableland = getConnection(signer, { rpcRelay: false });
+    // Note: use `getConnection` when rpcRelay is removed
+    const tableland = connect({
+      signer,
+      chain: "local-tableland",
+      rpcRelay: false,
+    });
 
     const prefix = "test_direct_invalid_id_write";
     await tableland.create("keyy TEXT, val TEXT", { prefix });
@@ -421,8 +434,12 @@ describe("Validator, Chain, and SDK work end to end", function () {
   it("set controller without relay", async function () {
     const signer = accounts[1];
 
-    // Note: options can be removed when rpcRelay is removed
-    const tableland = getConnection(signer, { rpcRelay: false });
+    // Note: use `getConnection` when rpcRelay is removed
+    const tableland = connect({
+      signer,
+      chain: "local-tableland",
+      rpcRelay: false,
+    });
 
     const prefix = "test_create_setcontroller_norelay";
     // `key` is a reserved word in sqlite
@@ -441,8 +458,10 @@ describe("Validator, Chain, and SDK work end to end", function () {
   it("set controller with relay", async function () {
     const signer = accounts[1];
 
-    // Note: options can be removed when rpcRelay is removed
-    const tableland = getConnection(signer, {
+    // Note: we can remove this test when rpcRelay is removed
+    const tableland = connect({
+      signer,
+      chain: "local-tableland",
       rpcRelay: true /* this is default `true`, just being explicit */,
     });
 
@@ -485,8 +504,12 @@ describe("Validator, Chain, and SDK work end to end", function () {
   it("lock controller without relay returns a transaction hash", async function () {
     const signer = accounts[1];
 
-    // Note: options can be removed when rpcRelay is removed
-    const tableland = getConnection(signer, { rpcRelay: false });
+    // Note: use `getConnection` when rpcRelay is removed
+    const tableland = connect({
+      signer,
+      chain: "local-tableland",
+      rpcRelay: false,
+    });
 
     const prefix = "test_create_lockcontroller";
     // `key` is a reserved word in sqlite

--- a/test/e2e.test.mjs
+++ b/test/e2e.test.mjs
@@ -1,12 +1,11 @@
 import chai from "chai";
-import { getTableland } from "./util.mjs";
-import { getAccounts } from "../dist/esm/util.js";
+import { getConnections } from "../dist/esm/util.js";
 import { LocalTableland } from "../dist/esm/main.js";
 
 const expect = chai.expect;
 
 describe("Validator, Chain, and SDK work end to end", function () {
-  const accounts = getAccounts();
+  const conns = getConnections();
   const lt = new LocalTableland({ silent: true });
 
   // These tests take a bit longer than normal since we are running them against an actual network
@@ -21,68 +20,54 @@ describe("Validator, Chain, and SDK work end to end", function () {
   });
 
   it("Creates a table that can be read from", async function () {
-    const signer = accounts[1];
-    const tableland = await getTableland(signer);
-
     const prefix = "test_create_read";
     // `key` is a reserved word in sqlite
-    const { tableId } = await tableland.create("keyy TEXT, val TEXT", {
+    const { tableId } = await conns[1].create("keyy TEXT, val TEXT", {
       prefix,
     });
 
     const chainId = 31337;
 
-    const data = await tableland.read(
+    const data = await conns[1].read(
       `SELECT * FROM ${prefix}_${chainId}_${tableId};`
     );
     expect(data.rows).to.eql([]);
   });
 
   it("Create a table that can be written to", async function () {
-    const signer = accounts[1];
-
-    const tableland = await getTableland(signer);
-
     const prefix = "test_create_write";
-    const { tableId } = await tableland.create("keyy TEXT, val TEXT", {
+    const { tableId } = await conns[1].create("keyy TEXT, val TEXT", {
       prefix,
     });
 
     const chainId = 31337;
     const queryableName = `${prefix}_${chainId}_${tableId}`;
 
-    const writeRes = await tableland.write(
+    const writeRes = await conns[1].write(
       `INSERT INTO ${queryableName} (keyy, val) VALUES ('tree', 'aspen')`
     );
 
-    const data = await tableland.read(`SELECT * FROM ${queryableName};`);
+    const data = await conns[1].read(`SELECT * FROM ${queryableName};`);
 
     expect(typeof writeRes.hash).to.eql("string");
     expect(data.rows).to.eql([["tree", "aspen"]]);
   });
 
   it("Table cannot be written to unless caller is allowed", async function () {
-    const signer = accounts[1];
-
-    const tableland = await getTableland(signer);
-
     const prefix = "test_not_allowed";
-    const { tableId } = await tableland.create("keyy TEXT, val TEXT", {
+    const { tableId } = await conns[1].create("keyy TEXT, val TEXT", {
       prefix,
     });
 
     const chainId = 31337;
     const queryableName = `${prefix}_${chainId}_${tableId}`;
 
-    const data = await tableland.read(`SELECT * FROM ${queryableName};`);
+    const data = await conns[1].read(`SELECT * FROM ${queryableName};`);
     expect(data.rows).to.eql([]);
-
-    const signer2 = accounts[2];
-    const tableland2 = await getTableland(signer2);
 
     await expect(
       (async function () {
-        await tableland2.write(
+        await conns[2].write(
           `INSERT INTO ${queryableName} (keyy, val) VALUES ('tree', 'aspen')`
         );
       })()
@@ -90,66 +75,58 @@ describe("Validator, Chain, and SDK work end to end", function () {
       "db query execution failed (code: ACL, msg: not enough privileges)"
     );
 
-    const data2 = await tableland2.read(`SELECT * FROM ${queryableName};`);
+    const data2 = await conns[2].read(`SELECT * FROM ${queryableName};`);
     expect(data2.rows).to.eql([]);
   });
 
   it("Create a table can have a row deleted", async function () {
-    const signer = accounts[1];
-
-    const tableland = await getTableland(signer);
-
     const prefix = "test_create_delete";
-    const { tableId } = await tableland.create("keyy TEXT, val TEXT", {
+    const { tableId } = await conns[1].create("keyy TEXT, val TEXT", {
       prefix,
     });
 
     const chainId = 31337;
     const queryableName = `${prefix}_${chainId}_${tableId}`;
 
-    const write1 = await tableland.write(
+    const write1 = await conns[1].write(
       `INSERT INTO ${queryableName} (keyy, val) VALUES ('tree', 'aspen')`
     );
 
     expect(typeof write1.hash).to.eql("string");
 
-    const write2 = await tableland.write(
+    const write2 = await conns[1].write(
       `INSERT INTO ${queryableName} (keyy, val) VALUES ('tree', 'pine')`
     );
 
     expect(typeof write2.hash).to.eql("string");
 
-    const data = await tableland.read(`SELECT * FROM ${queryableName};`);
+    const data = await conns[1].read(`SELECT * FROM ${queryableName};`);
     expect(data.rows.length).to.eql(2);
 
-    const delete1 = await tableland.write(
+    const delete1 = await conns[1].write(
       `DELETE FROM ${queryableName} WHERE val = 'pine';`
     );
 
     expect(typeof delete1.hash).to.eql("string");
 
-    const data2 = await tableland.read(`SELECT * FROM ${queryableName};`);
+    const data2 = await conns[1].read(`SELECT * FROM ${queryableName};`);
     await expect(data2.rows.length).to.eql(1);
   }, 30000);
 
   it("Read a table with `table` output", async function () {
-    const signer = accounts[1];
-
-    const tableland = await getTableland(signer);
-
     const prefix = "test_read";
-    const { tableId } = await tableland.create("keyy TEXT, val TEXT", {
+    const { tableId } = await conns[1].create("keyy TEXT, val TEXT", {
       prefix,
     });
 
     const chainId = 31337;
     const queryableName = `${prefix}_${chainId}_${tableId}`;
 
-    await tableland.write(
+    await conns[1].write(
       `INSERT INTO ${queryableName} (keyy, val) VALUES ('tree', 'aspen')`
     );
 
-    const data = await tableland.read(`SELECT * FROM ${queryableName};`, {
+    const data = await conns[1].read(`SELECT * FROM ${queryableName};`, {
       output: "table",
     });
 
@@ -160,49 +137,41 @@ describe("Validator, Chain, and SDK work end to end", function () {
   // TODO: this test fails because validator has casing issue
   // https://github.com/tablelandnetwork/go-tableland/issues/389
   it.skip("Count rows in a table", async function () {
-    const signer = accounts[1];
-
-    const tableland = await getTableland(signer);
-
     const prefix = "test_count";
-    const { tableId } = await tableland.create("keyy TEXT, val TEXT", {
+    const { tableId } = await conns[1].create("keyy TEXT, val TEXT", {
       prefix,
     });
 
     const chainId = 31337;
     const queryableName = `${prefix}_${chainId}_${tableId}`;
 
-    await tableland.write(
+    await conns[1].write(
       `INSERT INTO ${queryableName} (keyy, val) VALUES ('tree', 'aspen')`
     );
 
-    await tableland.write(
+    await conns[1].write(
       `INSERT INTO ${queryableName} (keyy, val) VALUES ('tree', 'pine')`
     );
 
-    const data = await tableland.read(`SELECT COUNT(*) FROM ${queryableName};`);
+    const data = await conns[1].read(`SELECT COUNT(*) FROM ${queryableName};`);
 
     expect(data).to.eql({ columns: [{ name: "COUNT(*)" }], rows: [[2]] });
   });
 
   it("Read a table with `objects` output", async function () {
-    const signer = accounts[1];
-
-    const tableland = await getTableland(signer);
-
     const prefix = "test_read";
-    const { tableId } = await tableland.create("keyy TEXT, val TEXT", {
+    const { tableId } = await conns[1].create("keyy TEXT, val TEXT", {
       prefix,
     });
 
     const chainId = 31337;
     const queryableName = `${prefix}_${chainId}_${tableId}`;
 
-    await tableland.write(
+    await conns[1].write(
       `INSERT INTO ${queryableName} (keyy, val) VALUES ('tree', 'aspen')`
     );
 
-    const data = await tableland.read(`SELECT * FROM ${queryableName};`, {
+    const data = await conns[1].read(`SELECT * FROM ${queryableName};`, {
       output: "objects",
     });
 
@@ -210,23 +179,19 @@ describe("Validator, Chain, and SDK work end to end", function () {
   });
 
   it("Read a single row with `unwrap` option", async function () {
-    const signer = accounts[1];
-
-    const tableland = await getTableland(signer);
-
     const prefix = "test_read";
-    const { tableId } = await tableland.create("keyy TEXT, val TEXT", {
+    const { tableId } = await conns[1].create("keyy TEXT, val TEXT", {
       prefix,
     });
 
     const chainId = 31337;
     const queryableName = `${prefix}_${chainId}_${tableId}`;
 
-    await tableland.write(
+    await conns[1].write(
       `INSERT INTO ${queryableName} (keyy, val) VALUES ('tree', 'aspen')`
     );
 
-    const data = await tableland.read(`SELECT * FROM ${queryableName};`, {
+    const data = await conns[1].read(`SELECT * FROM ${queryableName};`, {
       unwrap: true,
       output: "objects",
     });
@@ -235,28 +200,24 @@ describe("Validator, Chain, and SDK work end to end", function () {
   });
 
   it("Read two rows with `unwrap` option fails", async function () {
-    const signer = accounts[1];
-
-    const tableland = await getTableland(signer);
-
     const prefix = "test_read";
-    const { tableId } = await tableland.create("keyy TEXT, val TEXT", {
+    const { tableId } = await conns[1].create("keyy TEXT, val TEXT", {
       prefix,
     });
 
     const chainId = 31337;
     const queryableName = `${prefix}_${chainId}_${tableId}`;
 
-    await tableland.write(
+    await conns[1].write(
       `INSERT INTO ${queryableName} (keyy, val) VALUES ('tree', 'aspen')`
     );
-    await tableland.write(
+    await conns[1].write(
       `INSERT INTO ${queryableName} (keyy, val) VALUES ('tree', 'pine')`
     );
 
     await expect(
       (async function () {
-        await tableland.read(`SELECT * FROM ${queryableName};`, {
+        await conns[1].read(`SELECT * FROM ${queryableName};`, {
           unwrap: true,
           output: "objects",
         });
@@ -267,24 +228,18 @@ describe("Validator, Chain, and SDK work end to end", function () {
   });
 
   it("Read with `extract` option", async function () {
-    const signer = accounts[1];
-
-    const tableland = await getTableland(signer);
-
     const prefix = "test_read_extract";
-    const { tableId } = await tableland.create("val TEXT", {
+    const { tableId } = await conns[1].create("val TEXT", {
       prefix,
     });
 
     const chainId = 31337;
     const queryableName = `${prefix}_${chainId}_${tableId}`;
 
-    await tableland.write(
-      `INSERT INTO ${queryableName} (val) VALUES ('aspen')`
-    );
-    await tableland.write(`INSERT INTO ${queryableName} (val) VALUES ('pine')`);
+    await conns[1].write(`INSERT INTO ${queryableName} (val) VALUES ('aspen')`);
+    await conns[1].write(`INSERT INTO ${queryableName} (val) VALUES ('pine')`);
 
-    const data = await tableland.read(`SELECT * FROM ${queryableName};`, {
+    const data = await conns[1].read(`SELECT * FROM ${queryableName};`, {
       extract: true,
       output: "objects",
     });
@@ -293,25 +248,21 @@ describe("Validator, Chain, and SDK work end to end", function () {
   });
 
   it("Read table with two columns with `extract` option fails", async function () {
-    const signer = accounts[1];
-
-    const tableland = await getTableland(signer);
-
     const prefix = "test_read";
-    const { tableId } = await tableland.create("keyy TEXT, val TEXT", {
+    const { tableId } = await conns[1].create("keyy TEXT, val TEXT", {
       prefix,
     });
 
     const chainId = 31337;
     const queryableName = `${prefix}_${chainId}_${tableId}`;
 
-    await tableland.write(
+    await conns[1].write(
       `INSERT INTO ${queryableName} (keyy, val) VALUES ('tree', 'aspen')`
     );
 
     await expect(
       (async function () {
-        await tableland.read(`SELECT * FROM ${queryableName};`, {
+        await conns[1].read(`SELECT * FROM ${queryableName};`, {
           extract: true,
           output: "objects",
         });
@@ -322,60 +273,54 @@ describe("Validator, Chain, and SDK work end to end", function () {
   });
 
   it("List an account's tables", async function () {
-    const signer = accounts[1];
-
-    const tableland = await getTableland(signer);
-
     const prefix = "test_create_list";
-    const { tableId } = await tableland.create("keyy TEXT, val TEXT", {
+    const { tableId } = await conns[1].create("keyy TEXT, val TEXT", {
       prefix,
     });
 
     const chainId = 31337;
     const queryableName = `${prefix}_${chainId}_${tableId}`;
 
-    const tablesMeta = await tableland.list();
+    const tablesMeta = await conns[1].list();
 
     expect(Array.isArray(tablesMeta)).to.eql(true);
     const table = tablesMeta.find((table) => table.name === queryableName);
 
     expect(typeof table).to.equal("object");
-    expect(table.controller).to.eql(accounts[1].address);
+    expect(table.controller).to.eql(conns[1].signer.getAddress());
   });
 
   it("write to a table without using the relay", async function () {
-    const signer = accounts[1];
-
-    const tableland = await getTableland(signer, { rpcRelay: false });
+    conns[1].rpcRelay = false;
 
     const prefix = "test_direct_write";
-    const { tableId } = await tableland.create("keyy TEXT, val TEXT", {
+    const { tableId } = await conns[1].create("keyy TEXT, val TEXT", {
       prefix,
     });
 
     const chainId = 31337;
     const queryableName = `${prefix}_${chainId}_${tableId}`;
 
-    const writeRes = await tableland.write(
+    const writeRes = await conns[1].write(
       `INSERT INTO ${queryableName} (keyy, val) VALUES ('tree', 'aspen')`
     );
 
     expect(typeof writeRes.hash).to.eql("string");
 
-    const data = await tableland.read(`SELECT * FROM ${queryableName};`);
+    const data = await conns[1].read(`SELECT * FROM ${queryableName};`);
     expect(data.rows).to.eql([["tree", "aspen"]]);
+
+    conns[1].rpcRelay = true;
   });
 
   it("write without relay statement validates table name prefix", async function () {
-    const signer = accounts[1];
-
-    const tableland = await getTableland(signer, { rpcRelay: false });
+    conns[1].rpcRelay = false;
 
     const prefix = "test_direct_invalid_write";
-    await tableland.create("keyy TEXT, val TEXT", { prefix });
+    await conns[1].create("keyy TEXT, val TEXT", { prefix });
 
     const prefix2 = "test_direct_invalid_write2";
-    const { tableId } = await tableland.create("keyy TEXT, val TEXT", {
+    const { tableId } = await conns[1].create("keyy TEXT, val TEXT", {
       prefix: prefix2,
     });
 
@@ -385,29 +330,27 @@ describe("Validator, Chain, and SDK work end to end", function () {
 
     await expect(
       (async function () {
-        await tableland.write(
+        await conns[1].write(
           `INSERT INTO ${queryableName} (keyy, val) VALUES ('tree', 'aspen')`
         );
       })()
     ).to.be.rejectedWith(
       `table prefix doesn't match (exp ${prefix2}, got ${prefix})`
     );
+
+    conns[1].rpcRelay = true;
   });
 
   it("write without relay statement validates table ID", async function () {
-    const signer = accounts[1];
-
-    const tableland = await getTableland(signer, { rpcRelay: false });
-
     const prefix = "test_direct_invalid_id_write";
-    await tableland.create("keyy TEXT, val TEXT", { prefix });
+    await conns[1].create("keyy TEXT, val TEXT", { prefix });
 
     // the tableId 0 does not exist since we start with tableId == 1
     const queryableName = `${prefix}_31337_0`;
 
     await expect(
       (async function () {
-        await tableland.write(
+        await conns[1].write(
           `INSERT INTO ${queryableName} (keyy, val) VALUES ('tree', 'aspen')`
         );
       })()
@@ -417,37 +360,33 @@ describe("Validator, Chain, and SDK work end to end", function () {
   });
 
   it("set controller without relay", async function () {
-    const signer = accounts[1];
-
-    const tableland = await getTableland(signer, { rpcRelay: false });
+    conns[1].rpcRelay = false;
 
     const prefix = "test_create_setcontroller_norelay";
     // `key` is a reserved word in sqlite
-    const { name } = await tableland.create("keyy TEXT, val TEXT", { prefix });
+    const { name } = await conns[1].create("keyy TEXT, val TEXT", { prefix });
 
     // Set the controller to Hardhat #7
-    const { hash } = await tableland.setController(
+    const { hash } = await conns[1].setController(
       "0x14dC79964da2C08b23698B3D3cc7Ca32193d9955",
       name
     );
 
     expect(typeof hash).to.eql("string");
     expect(hash.length).to.eql(66);
+
+    conns[1].rpcRelay = true;
   });
 
   it("set controller with relay", async function () {
-    const signer = accounts[1];
-
-    const tableland = await getTableland(signer, {
-      rpcRelay: true /* this is default `true`, just being explicit */,
-    });
+    conns[1].rpcRelay = true;
 
     const prefix = "test_create_setcontroller_relay";
     // `key` is a reserved word in sqlite
-    const { name } = await tableland.create("keyy TEXT, val TEXT", { prefix });
+    const { name } = await conns[1].create("keyy TEXT, val TEXT", { prefix });
 
     // Set the controller to Hardhat #7
-    const { hash } = await tableland.setController(
+    const { hash } = await conns[1].setController(
       "0x14dC79964da2C08b23698B3D3cc7Ca32193d9955",
       name
     );
@@ -457,61 +396,53 @@ describe("Validator, Chain, and SDK work end to end", function () {
   });
 
   it("get controller returns an address", async function () {
-    const signer = accounts[1];
-
-    const tableland = await getTableland(signer);
-
     const prefix = "test_create_getcontroller";
     // `key` is a reserved word in sqlite
-    const { name } = await tableland.create("keyy TEXT, val TEXT", { prefix });
+    const { name } = await conns[1].create("keyy TEXT, val TEXT", { prefix });
 
     // Hardhat #7
     const controllerAddress = "0x14dC79964da2C08b23698B3D3cc7Ca32193d9955";
 
-    const { hash } = await tableland.setController(controllerAddress, name);
+    const { hash } = await conns[1].setController(controllerAddress, name);
 
     expect(typeof hash).to.eql("string");
     expect(hash.length).to.eql(66);
 
-    const controller = await tableland.getController(name);
+    const controller = await conns[1].getController(name);
 
     expect(controller).to.eql(controllerAddress);
   });
 
   it("lock controller without relay returns a transaction hash", async function () {
-    const signer = accounts[1];
-
-    const tableland = await getTableland(signer, { rpcRelay: false });
+    conns[1].rpcRelay = false;
 
     const prefix = "test_create_lockcontroller";
     // `key` is a reserved word in sqlite
-    const { name } = await tableland.create("keyy TEXT, val TEXT", { prefix });
+    const { name } = await conns[1].create("keyy TEXT, val TEXT", { prefix });
 
     // Hardhat #7
     const controllerAddress = "0x14dC79964da2C08b23698B3D3cc7Ca32193d9955";
 
-    const { hash } = await tableland.setController(controllerAddress, name);
+    const { hash } = await conns[1].setController(controllerAddress, name);
 
     expect(typeof hash).to.eql("string");
     expect(hash.length).to.eql(66);
 
-    const tx = await tableland.lockController(name);
+    const tx = await conns[1].lockController(name);
 
     expect(typeof tx.hash).to.eql("string");
+
+    conns[1].rpcRelay = true;
   });
 
   it("get the schema for a table", async function () {
-    const signer = accounts[1];
-
-    const tableland = await getTableland(signer);
-
     const prefix = "test_get_schema";
-    const { tableId } = await tableland.create("a INT PRIMARY KEY", { prefix });
+    const { tableId } = await conns[1].create("a INT PRIMARY KEY", { prefix });
 
     const chainId = 31337;
     const queryableName = `${prefix}_${chainId}_${tableId}`;
 
-    const tableSchema = await tableland.schema(queryableName);
+    const tableSchema = await conns[1].schema(queryableName);
 
     expect(typeof tableSchema.columns).to.eql("object");
     expect(Array.isArray(tableSchema.table_constraints)).to.eql(true);
@@ -523,41 +454,32 @@ describe("Validator, Chain, and SDK work end to end", function () {
   });
 
   it("get the structure for a hash", async function () {
-    const signer = accounts[1];
-
-    const tableland = await getTableland(signer);
-
     const prefix = "test_get_structure";
-    const { tableId } = await tableland.create("a TEXT, b INT PRIMARY KEY", {
+    const { tableId } = await conns[1].create("a TEXT, b INT PRIMARY KEY", {
       prefix,
     });
 
     const chainId = 31337;
     const queryableName = `${prefix}_${chainId}_${tableId}`;
 
-    const { structureHash } = await tableland.hash(
-      "a TEXT, b INT PRIMARY KEY",
-      { prefix }
-    );
+    const { structureHash } = await conns[1].hash("a TEXT, b INT PRIMARY KEY", {
+      prefix,
+    });
 
-    const tableStructure = await tableland.structure(structureHash);
+    const tableStructure = await conns[1].structure(structureHash);
 
     expect(Array.isArray(tableStructure)).to.eql(true);
 
     const lastStructure = tableStructure[tableStructure.length - 1];
 
     expect(lastStructure.name).to.eql(queryableName);
-    expect(lastStructure.controller).to.eql(accounts[1].address);
+    expect(lastStructure.controller).to.eql(conns[1].signer.getAddress());
     expect(lastStructure.structure).to.eql(structureHash);
   });
 
   it("A write that violates table constraints throws error", async function () {
-    const signer = accounts[1];
-
-    const tableland = await getTableland(signer);
-
     const prefix = "test_create_tc_violation";
-    const { tableId } = await tableland.create(
+    const { tableId } = await conns[1].create(
       "id TEXT, name TEXT, PRIMARY KEY(id)",
       {
         prefix,
@@ -569,7 +491,7 @@ describe("Validator, Chain, and SDK work end to end", function () {
 
     await expect(
       (async function () {
-        await tableland.write(
+        await conns[1].write(
           `INSERT INTO ${queryableName} VALUES (1, '1'), (1, '1')`
         );
       })()

--- a/test/e2e.test.mjs
+++ b/test/e2e.test.mjs
@@ -345,9 +345,8 @@ describe("Validator, Chain, and SDK work end to end", function () {
   it("write to a table without using the relay", async function () {
     const signer = accounts[1];
 
-    const tableland = getConnection(signer);
-    // Note: This can be removed when rpcRelay is removed
-    tableland.rpcRelay = false;
+    // Note: options can be removed when rpcRelay is removed
+    const tableland = getConnection(signer, { rpcRelay: false });
 
     const prefix = "test_direct_write";
     const { tableId } = await tableland.create("keyy TEXT, val TEXT", {
@@ -370,9 +369,8 @@ describe("Validator, Chain, and SDK work end to end", function () {
   it("write without relay statement validates table name prefix", async function () {
     const signer = accounts[1];
 
-    const tableland = getConnection(signer);
-    // Note: This can be removed when rpcRelay is removed
-    tableland.rpcRelay = false;
+    // Note: options can be removed when rpcRelay is removed
+    const tableland = getConnection(signer, { rpcRelay: false });
 
     const prefix = "test_direct_invalid_write";
     await tableland.create("keyy TEXT, val TEXT", { prefix });
@@ -393,16 +391,15 @@ describe("Validator, Chain, and SDK work end to end", function () {
         );
       })()
     ).to.be.rejectedWith(
-      `db query execution failed (code: TABLE_LOOKUP, msg: table prefix lookup for table id: table prefix lookup: no such table: ${queryableName})`
+      `calling ValidateWriteQuery: table prefix doesn't match (exp ${prefix2}, got ${prefix})`
     );
   });
 
   it("write without relay statement validates table ID", async function () {
     const signer = accounts[1];
 
-    const tableland = getConnection(signer);
-    // Note: This can be removed when rpcRelay is removed
-    tableland.rpcRelay = false;
+    // Note: options can be removed when rpcRelay is removed
+    const tableland = getConnection(signer, { rpcRelay: false });
 
     const prefix = "test_direct_invalid_id_write";
     await tableland.create("keyy TEXT, val TEXT", { prefix });
@@ -417,16 +414,15 @@ describe("Validator, Chain, and SDK work end to end", function () {
         );
       })()
     ).to.be.rejectedWith(
-      "calling RelayWriteQuery: sending tx: retryable RunSQL call: contract call: Error: VM Exception while processing transaction: reverted with custom error 'Unauthorized()'"
+      `getting table: failed to get the table: sql: no rows in result set`
     );
   });
 
   it("set controller without relay", async function () {
     const signer = accounts[1];
 
-    const tableland = getConnection(signer);
-    // Note: This can be removed when rpcRelay is removed
-    tableland.rpcRelay = false;
+    // Note: options can be removed when rpcRelay is removed
+    const tableland = getConnection(signer, { rpcRelay: false });
 
     const prefix = "test_create_setcontroller_norelay";
     // `key` is a reserved word in sqlite
@@ -445,9 +441,10 @@ describe("Validator, Chain, and SDK work end to end", function () {
   it("set controller with relay", async function () {
     const signer = accounts[1];
 
-    const tableland = getConnection(signer);
-    // Note: This can be removed when rpcRelay is removed
-    tableland.rpcRelay = true; /* this is default `true`, just being explicit */
+    // Note: options can be removed when rpcRelay is removed
+    const tableland = getConnection(signer, {
+      rpcRelay: true /* this is default `true`, just being explicit */,
+    });
 
     const prefix = "test_create_setcontroller_relay";
     // `key` is a reserved word in sqlite
@@ -488,9 +485,8 @@ describe("Validator, Chain, and SDK work end to end", function () {
   it("lock controller without relay returns a transaction hash", async function () {
     const signer = accounts[1];
 
-    const tableland = getConnection(signer);
-    // Note: This can be removed when rpcRelay is removed
-    tableland.rpcRelay = false;
+    // Note: options can be removed when rpcRelay is removed
+    const tableland = getConnection(signer, { rpcRelay: false });
 
     const prefix = "test_create_lockcontroller";
     // `key` is a reserved word in sqlite

--- a/test/e2e.test.mjs
+++ b/test/e2e.test.mjs
@@ -393,7 +393,7 @@ describe("Validator, Chain, and SDK work end to end", function () {
         );
       })()
     ).to.be.rejectedWith(
-      `table prefix doesn't match (exp ${prefix2}, got ${prefix})`
+      `db query execution failed (code: TABLE_LOOKUP, msg: table prefix lookup for table id: table prefix lookup: no such table: ${queryableName})`
     );
   });
 
@@ -417,7 +417,7 @@ describe("Validator, Chain, and SDK work end to end", function () {
         );
       })()
     ).to.be.rejectedWith(
-      `getting table: failed to get the table: sql: no rows in result set`
+      "calling RelayWriteQuery: sending tx: retryable RunSQL call: contract call: Error: VM Exception while processing transaction: reverted with custom error 'Unauthorized()'"
     );
   });
 

--- a/test/e2e.test.mjs
+++ b/test/e2e.test.mjs
@@ -1,11 +1,11 @@
 import chai from "chai";
-import { getConnections } from "../dist/esm/util.js";
+import { getAccounts, getConnection } from "../dist/esm/util.js";
 import { LocalTableland } from "../dist/esm/main.js";
 
 const expect = chai.expect;
 
 describe("Validator, Chain, and SDK work end to end", function () {
-  const conns = getConnections();
+  const accounts = getAccounts();
   const lt = new LocalTableland({ silent: true });
 
   // These tests take a bit longer than normal since we are running them against an actual network
@@ -20,54 +20,68 @@ describe("Validator, Chain, and SDK work end to end", function () {
   });
 
   it("Creates a table that can be read from", async function () {
+    const signer = accounts[1];
+    const tableland = getConnection(signer);
+
     const prefix = "test_create_read";
     // `key` is a reserved word in sqlite
-    const { tableId } = await conns[1].create("keyy TEXT, val TEXT", {
+    const { tableId } = await tableland.create("keyy TEXT, val TEXT", {
       prefix,
     });
 
     const chainId = 31337;
 
-    const data = await conns[1].read(
+    const data = await tableland.read(
       `SELECT * FROM ${prefix}_${chainId}_${tableId};`
     );
     expect(data.rows).to.eql([]);
   });
 
   it("Create a table that can be written to", async function () {
+    const signer = accounts[1];
+
+    const tableland = getConnection(signer);
+
     const prefix = "test_create_write";
-    const { tableId } = await conns[1].create("keyy TEXT, val TEXT", {
+    const { tableId } = await tableland.create("keyy TEXT, val TEXT", {
       prefix,
     });
 
     const chainId = 31337;
     const queryableName = `${prefix}_${chainId}_${tableId}`;
 
-    const writeRes = await conns[1].write(
+    const writeRes = await tableland.write(
       `INSERT INTO ${queryableName} (keyy, val) VALUES ('tree', 'aspen')`
     );
 
-    const data = await conns[1].read(`SELECT * FROM ${queryableName};`);
+    const data = await tableland.read(`SELECT * FROM ${queryableName};`);
 
     expect(typeof writeRes.hash).to.eql("string");
     expect(data.rows).to.eql([["tree", "aspen"]]);
   });
 
   it("Table cannot be written to unless caller is allowed", async function () {
+    const signer = accounts[1];
+
+    const tableland = getConnection(signer);
+
     const prefix = "test_not_allowed";
-    const { tableId } = await conns[1].create("keyy TEXT, val TEXT", {
+    const { tableId } = await tableland.create("keyy TEXT, val TEXT", {
       prefix,
     });
 
     const chainId = 31337;
     const queryableName = `${prefix}_${chainId}_${tableId}`;
 
-    const data = await conns[1].read(`SELECT * FROM ${queryableName};`);
+    const data = await tableland.read(`SELECT * FROM ${queryableName};`);
     expect(data.rows).to.eql([]);
+
+    const signer2 = accounts[2];
+    const tableland2 = getConnection(signer2);
 
     await expect(
       (async function () {
-        await conns[2].write(
+        await tableland2.write(
           `INSERT INTO ${queryableName} (keyy, val) VALUES ('tree', 'aspen')`
         );
       })()
@@ -75,58 +89,66 @@ describe("Validator, Chain, and SDK work end to end", function () {
       "db query execution failed (code: ACL, msg: not enough privileges)"
     );
 
-    const data2 = await conns[2].read(`SELECT * FROM ${queryableName};`);
+    const data2 = await tableland2.read(`SELECT * FROM ${queryableName};`);
     expect(data2.rows).to.eql([]);
   });
 
   it("Create a table can have a row deleted", async function () {
+    const signer = accounts[1];
+
+    const tableland = getConnection(signer);
+
     const prefix = "test_create_delete";
-    const { tableId } = await conns[1].create("keyy TEXT, val TEXT", {
+    const { tableId } = await tableland.create("keyy TEXT, val TEXT", {
       prefix,
     });
 
     const chainId = 31337;
     const queryableName = `${prefix}_${chainId}_${tableId}`;
 
-    const write1 = await conns[1].write(
+    const write1 = await tableland.write(
       `INSERT INTO ${queryableName} (keyy, val) VALUES ('tree', 'aspen')`
     );
 
     expect(typeof write1.hash).to.eql("string");
 
-    const write2 = await conns[1].write(
+    const write2 = await tableland.write(
       `INSERT INTO ${queryableName} (keyy, val) VALUES ('tree', 'pine')`
     );
 
     expect(typeof write2.hash).to.eql("string");
 
-    const data = await conns[1].read(`SELECT * FROM ${queryableName};`);
+    const data = await tableland.read(`SELECT * FROM ${queryableName};`);
     expect(data.rows.length).to.eql(2);
 
-    const delete1 = await conns[1].write(
+    const delete1 = await tableland.write(
       `DELETE FROM ${queryableName} WHERE val = 'pine';`
     );
 
     expect(typeof delete1.hash).to.eql("string");
 
-    const data2 = await conns[1].read(`SELECT * FROM ${queryableName};`);
+    const data2 = await tableland.read(`SELECT * FROM ${queryableName};`);
     await expect(data2.rows.length).to.eql(1);
   }, 30000);
 
   it("Read a table with `table` output", async function () {
+    const signer = accounts[1];
+
+    const tableland = getConnection(signer);
+
     const prefix = "test_read";
-    const { tableId } = await conns[1].create("keyy TEXT, val TEXT", {
+    const { tableId } = await tableland.create("keyy TEXT, val TEXT", {
       prefix,
     });
 
     const chainId = 31337;
     const queryableName = `${prefix}_${chainId}_${tableId}`;
 
-    await conns[1].write(
+    await tableland.write(
       `INSERT INTO ${queryableName} (keyy, val) VALUES ('tree', 'aspen')`
     );
 
-    const data = await conns[1].read(`SELECT * FROM ${queryableName};`, {
+    const data = await tableland.read(`SELECT * FROM ${queryableName};`, {
       output: "table",
     });
 
@@ -137,41 +159,49 @@ describe("Validator, Chain, and SDK work end to end", function () {
   // TODO: this test fails because validator has casing issue
   // https://github.com/tablelandnetwork/go-tableland/issues/389
   it.skip("Count rows in a table", async function () {
+    const signer = accounts[1];
+
+    const tableland = getConnection(signer);
+
     const prefix = "test_count";
-    const { tableId } = await conns[1].create("keyy TEXT, val TEXT", {
+    const { tableId } = await tableland.create("keyy TEXT, val TEXT", {
       prefix,
     });
 
     const chainId = 31337;
     const queryableName = `${prefix}_${chainId}_${tableId}`;
 
-    await conns[1].write(
+    await tableland.write(
       `INSERT INTO ${queryableName} (keyy, val) VALUES ('tree', 'aspen')`
     );
 
-    await conns[1].write(
+    await tableland.write(
       `INSERT INTO ${queryableName} (keyy, val) VALUES ('tree', 'pine')`
     );
 
-    const data = await conns[1].read(`SELECT COUNT(*) FROM ${queryableName};`);
+    const data = await tableland.read(`SELECT COUNT(*) FROM ${queryableName};`);
 
     expect(data).to.eql({ columns: [{ name: "COUNT(*)" }], rows: [[2]] });
   });
 
   it("Read a table with `objects` output", async function () {
+    const signer = accounts[1];
+
+    const tableland = getConnection(signer);
+
     const prefix = "test_read";
-    const { tableId } = await conns[1].create("keyy TEXT, val TEXT", {
+    const { tableId } = await tableland.create("keyy TEXT, val TEXT", {
       prefix,
     });
 
     const chainId = 31337;
     const queryableName = `${prefix}_${chainId}_${tableId}`;
 
-    await conns[1].write(
+    await tableland.write(
       `INSERT INTO ${queryableName} (keyy, val) VALUES ('tree', 'aspen')`
     );
 
-    const data = await conns[1].read(`SELECT * FROM ${queryableName};`, {
+    const data = await tableland.read(`SELECT * FROM ${queryableName};`, {
       output: "objects",
     });
 
@@ -179,19 +209,23 @@ describe("Validator, Chain, and SDK work end to end", function () {
   });
 
   it("Read a single row with `unwrap` option", async function () {
+    const signer = accounts[1];
+
+    const tableland = getConnection(signer);
+
     const prefix = "test_read";
-    const { tableId } = await conns[1].create("keyy TEXT, val TEXT", {
+    const { tableId } = await tableland.create("keyy TEXT, val TEXT", {
       prefix,
     });
 
     const chainId = 31337;
     const queryableName = `${prefix}_${chainId}_${tableId}`;
 
-    await conns[1].write(
+    await tableland.write(
       `INSERT INTO ${queryableName} (keyy, val) VALUES ('tree', 'aspen')`
     );
 
-    const data = await conns[1].read(`SELECT * FROM ${queryableName};`, {
+    const data = await tableland.read(`SELECT * FROM ${queryableName};`, {
       unwrap: true,
       output: "objects",
     });
@@ -200,24 +234,28 @@ describe("Validator, Chain, and SDK work end to end", function () {
   });
 
   it("Read two rows with `unwrap` option fails", async function () {
+    const signer = accounts[1];
+
+    const tableland = getConnection(signer);
+
     const prefix = "test_read";
-    const { tableId } = await conns[1].create("keyy TEXT, val TEXT", {
+    const { tableId } = await tableland.create("keyy TEXT, val TEXT", {
       prefix,
     });
 
     const chainId = 31337;
     const queryableName = `${prefix}_${chainId}_${tableId}`;
 
-    await conns[1].write(
+    await tableland.write(
       `INSERT INTO ${queryableName} (keyy, val) VALUES ('tree', 'aspen')`
     );
-    await conns[1].write(
+    await tableland.write(
       `INSERT INTO ${queryableName} (keyy, val) VALUES ('tree', 'pine')`
     );
 
     await expect(
       (async function () {
-        await conns[1].read(`SELECT * FROM ${queryableName};`, {
+        await tableland.read(`SELECT * FROM ${queryableName};`, {
           unwrap: true,
           output: "objects",
         });
@@ -228,18 +266,24 @@ describe("Validator, Chain, and SDK work end to end", function () {
   });
 
   it("Read with `extract` option", async function () {
+    const signer = accounts[1];
+
+    const tableland = getConnection(signer);
+
     const prefix = "test_read_extract";
-    const { tableId } = await conns[1].create("val TEXT", {
+    const { tableId } = await tableland.create("val TEXT", {
       prefix,
     });
 
     const chainId = 31337;
     const queryableName = `${prefix}_${chainId}_${tableId}`;
 
-    await conns[1].write(`INSERT INTO ${queryableName} (val) VALUES ('aspen')`);
-    await conns[1].write(`INSERT INTO ${queryableName} (val) VALUES ('pine')`);
+    await tableland.write(
+      `INSERT INTO ${queryableName} (val) VALUES ('aspen')`
+    );
+    await tableland.write(`INSERT INTO ${queryableName} (val) VALUES ('pine')`);
 
-    const data = await conns[1].read(`SELECT * FROM ${queryableName};`, {
+    const data = await tableland.read(`SELECT * FROM ${queryableName};`, {
       extract: true,
       output: "objects",
     });
@@ -248,21 +292,25 @@ describe("Validator, Chain, and SDK work end to end", function () {
   });
 
   it("Read table with two columns with `extract` option fails", async function () {
+    const signer = accounts[1];
+
+    const tableland = getConnection(signer);
+
     const prefix = "test_read";
-    const { tableId } = await conns[1].create("keyy TEXT, val TEXT", {
+    const { tableId } = await tableland.create("keyy TEXT, val TEXT", {
       prefix,
     });
 
     const chainId = 31337;
     const queryableName = `${prefix}_${chainId}_${tableId}`;
 
-    await conns[1].write(
+    await tableland.write(
       `INSERT INTO ${queryableName} (keyy, val) VALUES ('tree', 'aspen')`
     );
 
     await expect(
       (async function () {
-        await conns[1].read(`SELECT * FROM ${queryableName};`, {
+        await tableland.read(`SELECT * FROM ${queryableName};`, {
           extract: true,
           output: "objects",
         });
@@ -273,54 +321,64 @@ describe("Validator, Chain, and SDK work end to end", function () {
   });
 
   it("List an account's tables", async function () {
+    const signer = accounts[1];
+
+    const tableland = getConnection(signer);
+
     const prefix = "test_create_list";
-    const { tableId } = await conns[1].create("keyy TEXT, val TEXT", {
+    const { tableId } = await tableland.create("keyy TEXT, val TEXT", {
       prefix,
     });
 
     const chainId = 31337;
     const queryableName = `${prefix}_${chainId}_${tableId}`;
 
-    const tablesMeta = await conns[1].list();
+    const tablesMeta = await tableland.list();
 
     expect(Array.isArray(tablesMeta)).to.eql(true);
     const table = tablesMeta.find((table) => table.name === queryableName);
 
     expect(typeof table).to.equal("object");
-    expect(table.controller).to.eql(conns[1].signer.getAddress());
+    expect(table.controller).to.eql(accounts[1].address);
   });
 
   it("write to a table without using the relay", async function () {
-    conns[1].rpcRelay = false;
+    const signer = accounts[1];
+
+    const tableland = getConnection(signer);
+    // Note: This can be removed when rpcRelay is removed
+    tableland.rpcRelay = false;
 
     const prefix = "test_direct_write";
-    const { tableId } = await conns[1].create("keyy TEXT, val TEXT", {
+    const { tableId } = await tableland.create("keyy TEXT, val TEXT", {
       prefix,
     });
 
     const chainId = 31337;
     const queryableName = `${prefix}_${chainId}_${tableId}`;
 
-    const writeRes = await conns[1].write(
+    const writeRes = await tableland.write(
       `INSERT INTO ${queryableName} (keyy, val) VALUES ('tree', 'aspen')`
     );
 
     expect(typeof writeRes.hash).to.eql("string");
 
-    const data = await conns[1].read(`SELECT * FROM ${queryableName};`);
+    const data = await tableland.read(`SELECT * FROM ${queryableName};`);
     expect(data.rows).to.eql([["tree", "aspen"]]);
-
-    conns[1].rpcRelay = true;
   });
 
   it("write without relay statement validates table name prefix", async function () {
-    conns[1].rpcRelay = false;
+    const signer = accounts[1];
+
+    const tableland = getConnection(signer);
+    // Note: This can be removed when rpcRelay is removed
+    tableland.rpcRelay = false;
 
     const prefix = "test_direct_invalid_write";
-    await conns[1].create("keyy TEXT, val TEXT", { prefix });
+    await tableland.create("keyy TEXT, val TEXT", { prefix });
 
     const prefix2 = "test_direct_invalid_write2";
-    const { tableId } = await conns[1].create("keyy TEXT, val TEXT", {
+    const { tableId } = await tableland.create("keyy TEXT, val TEXT", {
       prefix: prefix2,
     });
 
@@ -330,27 +388,31 @@ describe("Validator, Chain, and SDK work end to end", function () {
 
     await expect(
       (async function () {
-        await conns[1].write(
+        await tableland.write(
           `INSERT INTO ${queryableName} (keyy, val) VALUES ('tree', 'aspen')`
         );
       })()
     ).to.be.rejectedWith(
       `table prefix doesn't match (exp ${prefix2}, got ${prefix})`
     );
-
-    conns[1].rpcRelay = true;
   });
 
   it("write without relay statement validates table ID", async function () {
+    const signer = accounts[1];
+
+    const tableland = getConnection(signer);
+    // Note: This can be removed when rpcRelay is removed
+    tableland.rpcRelay = false;
+
     const prefix = "test_direct_invalid_id_write";
-    await conns[1].create("keyy TEXT, val TEXT", { prefix });
+    await tableland.create("keyy TEXT, val TEXT", { prefix });
 
     // the tableId 0 does not exist since we start with tableId == 1
     const queryableName = `${prefix}_31337_0`;
 
     await expect(
       (async function () {
-        await conns[1].write(
+        await tableland.write(
           `INSERT INTO ${queryableName} (keyy, val) VALUES ('tree', 'aspen')`
         );
       })()
@@ -360,33 +422,39 @@ describe("Validator, Chain, and SDK work end to end", function () {
   });
 
   it("set controller without relay", async function () {
-    conns[1].rpcRelay = false;
+    const signer = accounts[1];
+
+    const tableland = getConnection(signer);
+    // Note: This can be removed when rpcRelay is removed
+    tableland.rpcRelay = false;
 
     const prefix = "test_create_setcontroller_norelay";
     // `key` is a reserved word in sqlite
-    const { name } = await conns[1].create("keyy TEXT, val TEXT", { prefix });
+    const { name } = await tableland.create("keyy TEXT, val TEXT", { prefix });
 
     // Set the controller to Hardhat #7
-    const { hash } = await conns[1].setController(
+    const { hash } = await tableland.setController(
       "0x14dC79964da2C08b23698B3D3cc7Ca32193d9955",
       name
     );
 
     expect(typeof hash).to.eql("string");
     expect(hash.length).to.eql(66);
-
-    conns[1].rpcRelay = true;
   });
 
   it("set controller with relay", async function () {
-    conns[1].rpcRelay = true;
+    const signer = accounts[1];
+
+    const tableland = getConnection(signer);
+    // Note: This can be removed when rpcRelay is removed
+    tableland.rpcRelay = true; /* this is default `true`, just being explicit */
 
     const prefix = "test_create_setcontroller_relay";
     // `key` is a reserved word in sqlite
-    const { name } = await conns[1].create("keyy TEXT, val TEXT", { prefix });
+    const { name } = await tableland.create("keyy TEXT, val TEXT", { prefix });
 
     // Set the controller to Hardhat #7
-    const { hash } = await conns[1].setController(
+    const { hash } = await tableland.setController(
       "0x14dC79964da2C08b23698B3D3cc7Ca32193d9955",
       name
     );
@@ -396,53 +464,63 @@ describe("Validator, Chain, and SDK work end to end", function () {
   });
 
   it("get controller returns an address", async function () {
+    const signer = accounts[1];
+
+    const tableland = getConnection(signer);
+
     const prefix = "test_create_getcontroller";
     // `key` is a reserved word in sqlite
-    const { name } = await conns[1].create("keyy TEXT, val TEXT", { prefix });
+    const { name } = await tableland.create("keyy TEXT, val TEXT", { prefix });
 
     // Hardhat #7
     const controllerAddress = "0x14dC79964da2C08b23698B3D3cc7Ca32193d9955";
 
-    const { hash } = await conns[1].setController(controllerAddress, name);
+    const { hash } = await tableland.setController(controllerAddress, name);
 
     expect(typeof hash).to.eql("string");
     expect(hash.length).to.eql(66);
 
-    const controller = await conns[1].getController(name);
+    const controller = await tableland.getController(name);
 
     expect(controller).to.eql(controllerAddress);
   });
 
   it("lock controller without relay returns a transaction hash", async function () {
-    conns[1].rpcRelay = false;
+    const signer = accounts[1];
+
+    const tableland = getConnection(signer);
+    // Note: This can be removed when rpcRelay is removed
+    tableland.rpcRelay = false;
 
     const prefix = "test_create_lockcontroller";
     // `key` is a reserved word in sqlite
-    const { name } = await conns[1].create("keyy TEXT, val TEXT", { prefix });
+    const { name } = await tableland.create("keyy TEXT, val TEXT", { prefix });
 
     // Hardhat #7
     const controllerAddress = "0x14dC79964da2C08b23698B3D3cc7Ca32193d9955";
 
-    const { hash } = await conns[1].setController(controllerAddress, name);
+    const { hash } = await tableland.setController(controllerAddress, name);
 
     expect(typeof hash).to.eql("string");
     expect(hash.length).to.eql(66);
 
-    const tx = await conns[1].lockController(name);
+    const tx = await tableland.lockController(name);
 
     expect(typeof tx.hash).to.eql("string");
-
-    conns[1].rpcRelay = true;
   });
 
   it("get the schema for a table", async function () {
+    const signer = accounts[1];
+
+    const tableland = getConnection(signer);
+
     const prefix = "test_get_schema";
-    const { tableId } = await conns[1].create("a INT PRIMARY KEY", { prefix });
+    const { tableId } = await tableland.create("a INT PRIMARY KEY", { prefix });
 
     const chainId = 31337;
     const queryableName = `${prefix}_${chainId}_${tableId}`;
 
-    const tableSchema = await conns[1].schema(queryableName);
+    const tableSchema = await tableland.schema(queryableName);
 
     expect(typeof tableSchema.columns).to.eql("object");
     expect(Array.isArray(tableSchema.table_constraints)).to.eql(true);
@@ -454,32 +532,41 @@ describe("Validator, Chain, and SDK work end to end", function () {
   });
 
   it("get the structure for a hash", async function () {
+    const signer = accounts[1];
+
+    const tableland = getConnection(signer);
+
     const prefix = "test_get_structure";
-    const { tableId } = await conns[1].create("a TEXT, b INT PRIMARY KEY", {
+    const { tableId } = await tableland.create("a TEXT, b INT PRIMARY KEY", {
       prefix,
     });
 
     const chainId = 31337;
     const queryableName = `${prefix}_${chainId}_${tableId}`;
 
-    const { structureHash } = await conns[1].hash("a TEXT, b INT PRIMARY KEY", {
-      prefix,
-    });
+    const { structureHash } = await tableland.hash(
+      "a TEXT, b INT PRIMARY KEY",
+      { prefix }
+    );
 
-    const tableStructure = await conns[1].structure(structureHash);
+    const tableStructure = await tableland.structure(structureHash);
 
     expect(Array.isArray(tableStructure)).to.eql(true);
 
     const lastStructure = tableStructure[tableStructure.length - 1];
 
     expect(lastStructure.name).to.eql(queryableName);
-    expect(lastStructure.controller).to.eql(conns[1].signer.getAddress());
+    expect(lastStructure.controller).to.eql(accounts[1].address);
     expect(lastStructure.structure).to.eql(structureHash);
   });
 
   it("A write that violates table constraints throws error", async function () {
+    const signer = accounts[1];
+
+    const tableland = getConnection(signer);
+
     const prefix = "test_create_tc_violation";
-    const { tableId } = await conns[1].create(
+    const { tableId } = await tableland.create(
       "id TEXT, name TEXT, PRIMARY KEY(id)",
       {
         prefix,
@@ -491,7 +578,7 @@ describe("Validator, Chain, and SDK work end to end", function () {
 
     await expect(
       (async function () {
-        await conns[1].write(
+        await tableland.write(
           `INSERT INTO ${queryableName} VALUES (1, '1'), (1, '1')`
         );
       })()

--- a/test/util.mjs
+++ b/test/util.mjs
@@ -1,17 +1,8 @@
 import fs from "fs";
 import { expect } from "chai";
 import yaml from "js-yaml";
-import { connect } from "@tableland/sdk";
 
 export const HOST = "http://localhost:8080";
-
-export const getTableland = function (signer, options = {}) {
-  return connect({
-    signer,
-    chain: "local-tableland",
-    ...options,
-  });
-};
 
 export const testRpcResponse = async function (res, expected) {
   if (!res.ok) throw new Error(res.statusText);


### PR DESCRIPTION
@joewagner this is what i was thinking for mirroring what hardhat does with `getAccounts`. just spit back tableland connections, mapped to the underlying hardhat accounts. this way no need to create a `Wallet` and setup a provider for each test. 