### PR TITLE
Enable test debugging via ide like vscode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableland/local",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableland/local",
-      "version": "0.0.3",
+      "version": "0.0.4",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tableland/local",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Tooling to start a sandboxed Tableland network.",
   "repository": "https://github.com/tablelandnetwork/local-tableland",
   "license": "MIT",

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,6 +18,7 @@ import {
   getConnection,
   logSync,
   isWindows,
+  inDebugMode,
 } from "./util.js";
 
 const spawnSync = spawn.sync;
@@ -106,7 +107,8 @@ class LocalTableland {
         {
           cwd: this.registryDir,
         }
-      )
+      ),
+      !inDebugMode()
     );
 
     // TODO: need to determine if we are starting the validator via docker

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,3 +1,4 @@
+import inspector from "node:inspector";
 import { isAbsolute, join, resolve } from "node:path";
 import { EventEmitter } from "node:events";
 import { Readable } from "node:stream";
@@ -126,6 +127,12 @@ const isExtraneousLog = function (log: string) {
 
 export const isWindows = function () {
   return process.platform === "win32";
+};
+
+export const inDebugMode = function () {
+  // This seems to be the only relyable way to determine if the process
+  // is being debugged either at startup, or during runtime (e.g. vscode)
+  return inspector.url() !== undefined;
 };
 
 export const logSync = function (


### PR DESCRIPTION
The sync process logging function was potentially throwing if the sync process had anything piped to stderr.
When vscode (and probably other IDEs) enables debugging at runtime it pipes some messages to stderr, which was stopping the initialization of the network.

I don't know why vscode would pipe to stderr when the debugged is attached, but we can work around it be determining if the network is being run in debug mode and not throwing the stderr output.