### PR TITLE
update validator config file

### DIFF
--- a/src/validators.ts
+++ b/src/validators.ts
@@ -176,7 +176,7 @@ class ValidatorDev {
   cleanup() {
     logSync(spawnSync("docker", ["container", "prune", "-f"]));
 
-    spawnSync("docker", ["image", "rm", "docker_api", "-f"]);
+    spawnSync("docker", ["image", "rm", "docker-api", "-f"]);
     spawnSync("docker", ["volume", "prune", "-f"]);
 
     const dbFiles = [

--- a/test/e2e.test.mjs
+++ b/test/e2e.test.mjs
@@ -157,7 +157,7 @@ describe("Validator, Chain, and SDK work end to end", function () {
   });
 
   // TODO: this test fails because validator has casing issue
-  // https://github.com/tablelandnetwork/go-tableland/issues/389
+  // https://github.com/tablelandnetwork/go-tableland/issues/393
   it.skip("Count rows in a table", async function () {
     const signer = accounts[1];
 

--- a/validator/config.json
+++ b/validator/config.json
@@ -7,7 +7,7 @@
   },
   "Gateway": {
     "ExternalURIPrefix": "http://localhost:8080",
-    "MetadataRendererURI": "https://render.tableland.xyz"
+    "AnimationRendererURI": "https://render.tableland.xyz"
   },
   "DB": {
     "Port": "5432"


### PR DESCRIPTION
This updates the config file used to start the Validator as per the changes in https://github.com/tablelandnetwork/go-tableland/pull/403
There's also a fix to docker cleanup when the local net is run via docker.