### PR TITLE
when using this for core dev via docker, use local-down

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -213,11 +213,7 @@ class LocalTableland {
       if (!(this.validator && this.validator.process)) return resolve();
 
       this.validator.process.on("close", () => resolve());
-      // If this Class is imported and run by a test runner then the ChildProcess instances are
-      // sub-processes of a ChildProcess instance which means in order to kill them in a way that
-      // enables graceful shut down they have to run in detached mode and be killed by the pid
-      // @ts-ignore
-      process.kill(-this.validator.process.pid);
+      this.validator.shutdown();
     });
   }
 

--- a/src/validators.ts
+++ b/src/validators.ts
@@ -176,7 +176,7 @@ class ValidatorDev {
   cleanup() {
     logSync(spawnSync("docker", ["container", "prune", "-f"]));
 
-    spawnSync("docker", ["image", "rm", "docker_api", "-f"]);
+    spawnSync("docker", ["image", "rm", "docker-api", "-f"]);
     spawnSync("docker", ["volume", "prune", "-f"]);
 
     const dbFiles = [

--- a/src/validators.ts
+++ b/src/validators.ts
@@ -143,13 +143,6 @@ class ValidatorDev {
   }
 
   start() {
-    // Add an empty .env file to the validator. The Validator expects this to exist,
-    // but doesn't need any of the values when running a local instance
-    writeFileSync(
-      join(this.validatorDir, "docker", "local", "api", ".env_validator"),
-      " "
-    );
-
     // Add the registry address to the Validator config
     // TODO: when https://github.com/tablelandnetwork/go-tableland/issues/317 is
     //       resolved we may be able to refactor alot of this

--- a/src/validators.ts
+++ b/src/validators.ts
@@ -111,6 +111,14 @@ class ValidatorPkg {
     );
   }
 
+  shutdown() {
+    // If this Class is imported and run by a test runner then the ChildProcess instances are
+    // sub-processes of a ChildProcess instance which means in order to kill them in a way that
+    // enables graceful shut down they have to run in detached mode and be killed by the pid
+    // @ts-ignore
+    process.kill(-this.validator.process.pid);
+  }
+
   // fully nuke the database
   cleanup() {
     shell.rm("-rf", resolve(this.validatorDir, "backups"));
@@ -169,6 +177,13 @@ class ValidatorDev {
     this.process = spawn("make", ["local-up"], {
       // we can't run in windows if we use detached mode
       detached: !isWindows(),
+      cwd: join(this.validatorDir, "docker"),
+    });
+  }
+
+  shutdown() {
+    // The validator uses make to shutdown when run via docker
+    spawnSync("make", ["local-down"], {
       cwd: join(this.validatorDir, "docker"),
     });
   }

--- a/src/validators.ts
+++ b/src/validators.ts
@@ -112,11 +112,12 @@ class ValidatorPkg {
   }
 
   shutdown() {
+    if (!this.process) throw new Error("Cannot find validator process");
     // If this Class is imported and run by a test runner then the ChildProcess instances are
     // sub-processes of a ChildProcess instance which means in order to kill them in a way that
     // enables graceful shut down they have to run in detached mode and be killed by the pid
     // @ts-ignore
-    process.kill(-this.validator.process.pid);
+    process.kill(-this.process.pid);
   }
 
   // fully nuke the database

--- a/test/e2e.test.mjs
+++ b/test/e2e.test.mjs
@@ -157,7 +157,7 @@ describe("Validator, Chain, and SDK work end to end", function () {
   });
 
   // TODO: this test fails because validator has casing issue
-  // https://github.com/tablelandnetwork/go-tableland/issues/389
+  // https://github.com/tablelandnetwork/go-tableland/issues/393
   it.skip("Count rows in a table", async function () {
     const signer = accounts[1];
 

--- a/validator/config.json
+++ b/validator/config.json
@@ -7,7 +7,7 @@
   },
   "Gateway": {
     "ExternalURIPrefix": "http://localhost:8080",
-    "MetadataRendererURI": "https://render.tableland.xyz"
+    "AnimationRendererURI": "https://render.tableland.xyz"
   },
   "DB": {
     "Port": "5432"


### PR DESCRIPTION
This fixes #48 
Instead of simply killing the validator process this uses the Validator's `make local-down` script to shutdown more cleanly.
This PR also includes an update to the new Validator config file schema, and some fixes to the docker cleanup processes.
Depends on https://github.com/tablelandnetwork/go-tableland/pull/406