### PR TITLE
Enable setting the verbose and silent options via config file

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -57,10 +57,10 @@ class LocalTableland {
     if (typeof config.verbose === "boolean") this.verbose = config.verbose;
     if (typeof config.silent === "boolean") this.silent = config.silent;
 
-    await this.#_start();
+    await this.#_start(config);
   }
 
-  async #_start() {
+  async #_start(config: Config = {}) {
     if (!this.registryDir) {
       throw new Error("cannot start a local network without Registry");
     }
@@ -165,6 +165,8 @@ class LocalTableland {
     console.log("        /              \\");
     console.log("       /                \\");
     console.log("______/                  \\______\n\n");
+    console.log("Using Configuration:\n" + JSON.stringify(config, null, 4));
+    console.log("\n\n*************************************\n");
   }
 
   async #_setReady() {

--- a/src/main.ts
+++ b/src/main.ts
@@ -112,9 +112,8 @@ class LocalTableland {
       !inDebugMode()
     );
 
-    // TODO: need to determine if we are starting the validator via docker
+    // need to determine if we are starting the validator via docker
     // and a local repo, or if are running a binary etc...
-
     const ValidatorClass = this.validatorDir ? ValidatorDev : ValidatorPkg;
 
     this.validator = new ValidatorClass(this.validatorDir);

--- a/src/up.ts
+++ b/src/up.ts
@@ -31,11 +31,11 @@ const argv = yargs(hideBin(process.argv)).options({
 }).argv;
 
 const go = async function () {
-  // using these argv ts ignores for the reasons explained in the yargs readme.
+  // casting argv to `any` for the reasons explained in the yargs readme.
   // https://github.com/yargs/yargs/blob/main/docs/typescript.md#typescript-usage-examples
   // TODO: try `parseSync`
-  // @ts-ignore
-  if (argv.init) {
+  const tsArgv = argv as any;
+  if (tsArgv.init) {
     // If init arg is given we want to open a terminal prompt that will
     // help the user setup their project directory then exit when finished
     await projectBuilder();
@@ -44,14 +44,10 @@ const go = async function () {
 
   const opts: Config = {};
 
-  // @ts-ignore
-  if (argv.validator) opts.validator = argv.validator;
-  // @ts-ignore
-  if (argv.registry) opts.registry = argv.registry;
-  // @ts-ignore
-  if (typeof argv.verbose === "boolean") opts.verbose = argv.verbose;
-  // @ts-ignore
-  if (typeof argv.silent === "boolean") opts.silent = argv.silent;
+  if (tsArgv.validator) opts.validator = tsArgv.validator;
+  if (tsArgv.registry) opts.registry = tsArgv.registry;
+  if (typeof tsArgv.verbose === "boolean") opts.verbose = tsArgv.verbose;
+  if (typeof tsArgv.silent === "boolean") opts.silent = tsArgv.silent;
 
   const tableland = new LocalTableland(opts);
 

--- a/src/up.ts
+++ b/src/up.ts
@@ -39,8 +39,8 @@ const go = async function () {
   // TODO: try `parseSync`
   // @ts-ignore
   if (argv.init) {
-    // If these aren't specified then we want to open a terminal prompt that
-    // will help the user setup their project directory then exit when finished
+    // If init arg is given we want to open a terminal prompt that will
+    // help the user setup their project directory then exit when finished
     await projectBuilder();
     return;
   }
@@ -53,11 +53,10 @@ const go = async function () {
   const opts: Config = {
     validator: argvValidator,
     registry: argvRegistry,
-    // @ts-ignore
-    verbose: argv.verbose,
-    // @ts-ignore
-    silent: argv.silent,
   };
+
+  if (typeof argv.verbose === "boolean") opts.verbose = argv.verbose;
+  if (typeof argv.silent === "boolean") opts.silent = argv.silent;
 
   const tableland = new LocalTableland(opts);
 

--- a/src/up.ts
+++ b/src/up.ts
@@ -13,17 +13,14 @@ const argv = yargs(hideBin(process.argv)).options({
   },
   registry: {
     type: "string",
-    default: "",
     description: "Path the the Tableland Registry contract repository",
   },
   verbose: {
     type: "boolean",
-    default: false,
     description: "Output verbose logs to stdout",
   },
   silent: {
     type: "boolean",
-    default: false,
     description: "Silence all output to stdout",
   },
   init: {
@@ -45,17 +42,15 @@ const go = async function () {
     return;
   }
 
-  // @ts-ignore
-  const argvValidator = argv.validator;
-  // @ts-ignore
-  const argvRegistry = argv.registry;
+  const opts: Config = {};
 
-  const opts: Config = {
-    validator: argvValidator,
-    registry: argvRegistry,
-  };
-
+  // @ts-ignore
+  if (argv.validator) opts.validator = argv.validator;
+  // @ts-ignore
+  if (argv.registry) opts.registry = argv.registry;
+  // @ts-ignore
   if (typeof argv.verbose === "boolean") opts.verbose = argv.verbose;
+  // @ts-ignore
   if (typeof argv.silent === "boolean") opts.silent = argv.silent;
 
   const tableland = new LocalTableland(opts);

--- a/src/validators.ts
+++ b/src/validators.ts
@@ -101,6 +101,7 @@ class ValidatorDev {
 
     // TODO: this could be parsed out of the deploy process, but since
     //       it's always the same address just hardcoding it here
+    // TODO: maybe we can get this from evm-tableland?
     validatorConfig.Chains[0].Registry.ContractAddress =
       "0xe7f1725e7734ce288f8367e1bb143e90bb3f0512";
 


### PR DESCRIPTION
The default values that yargs was setting were not allowing the config file to specify the verbose and silent options.
Fixes #127 