### PR TITLE
update the source and tests to make use of the incoming v4 sdk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@tableland/sdk": "^3.1.5",
+        "@tableland/sdk": "^4.0.0-pre.1",
         "@tableland/validator": "^0.0.2",
         "cross-spawn": "^7.0.3",
         "enquirer": "^2.3.6",
@@ -793,6 +793,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.2.tgz",
       "integrity": "sha512-KYRCASVTv6aeUi1tsF8/vpyR7zpfs3FUzy2Jqm+MU+LmUKhQ0y2FpfwqkCcxSg2ua4GALJd8k2R76WxwZGbQpA==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -1565,71 +1566,29 @@
         "node": ">=6"
       }
     },
-    "node_modules/@spruceid/siwe-parser": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@spruceid/siwe-parser/-/siwe-parser-2.0.2.tgz",
-      "integrity": "sha512-9WuA0ios2537cWYu39MMeH0O2KdrMKgKlOBUTWRTXQjCYu5B+mHCA0JkCbFaJ/0EjxoVIcYCXIW/DoPEpw+PqA==",
-      "dependencies": {
-        "@noble/hashes": "^1.1.2",
-        "apg-js": "^4.1.1",
-        "uri-js": "^4.4.1",
-        "valid-url": "^1.0.9"
-      }
-    },
-    "node_modules/@stablelib/base64": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
-      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ=="
-    },
-    "node_modules/@stablelib/binary": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@stablelib/binary/-/binary-1.0.1.tgz",
-      "integrity": "sha512-ClJWvmL6UBM/wjkvv/7m5VP3GMr9t0osr4yVgLZsLCOz4hGN9gIAFEqnJ0TsSMAN+n840nf2cHZnA5/KFqHC7Q==",
-      "dependencies": {
-        "@stablelib/int": "^1.0.1"
-      }
-    },
-    "node_modules/@stablelib/int": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@stablelib/int/-/int-1.0.1.tgz",
-      "integrity": "sha512-byr69X/sDtDiIjIV6m4roLVWnNNlRGzsvxw+agj8CIEazqWGOQp2dTYgQhtyVXV9wpO6WyXRQUzLV/JRNumT2w=="
-    },
-    "node_modules/@stablelib/random": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@stablelib/random/-/random-1.0.2.tgz",
-      "integrity": "sha512-rIsE83Xpb7clHPVRlBj8qNe5L8ISQOzjghYQm/dZ7VaM2KHYwMW5adjQjrzTZCchFnNCNhkwtnOBa9HTMJCI8w==",
-      "dependencies": {
-        "@stablelib/binary": "^1.0.1",
-        "@stablelib/wipe": "^1.0.1"
-      }
-    },
-    "node_modules/@stablelib/wipe": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@stablelib/wipe/-/wipe-1.0.1.tgz",
-      "integrity": "sha512-WfqfX/eXGiAd3RJe4VU2snh/ZPwtSjLG4ynQ/vYzvghTh7dHFcI1wl+nrkWG6lGhukOxOsUHfv8dUXr58D0ayg=="
-    },
     "node_modules/@tableland/evm": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@tableland/evm/-/evm-3.0.3.tgz",
-      "integrity": "sha512-Ci8QJubb6Z4ipPANALqAPQ9byh0tsRWZREej8QXGqLfHRqCAJfnMRTy2f47Oqq7IQ6Ajcy5holeUr9EtSmXNXA==",
+      "version": "4.0.0-pre.2",
+      "resolved": "https://registry.npmjs.org/@tableland/evm/-/evm-4.0.0-pre.2.tgz",
+      "integrity": "sha512-Cx+eVlovLvvUFkudlzBAMHh81J6LIuCNwDujNty+wgnpmkGJ/CJSP/gGe8VV/nchWyWkG3jPBaGRPa6Qi4xK2g==",
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@tableland/sdk": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/@tableland/sdk/-/sdk-3.1.5.tgz",
-      "integrity": "sha512-iq+1bsdxNDEGXFgEYAEYdPYjitkvqn4Y6r7B1eOUQmQ3GBErEaWUZfp9XI/CG6K/ZLmkpLettG9FF8FNNA52dA==",
+      "version": "4.0.0-pre.1",
+      "resolved": "https://registry.npmjs.org/@tableland/sdk/-/sdk-4.0.0-pre.1.tgz",
+      "integrity": "sha512-aE0Qco87Rr/LkHkypIaghHQexwVo1TFIA0+prDs6qc4k9UIyUnelBpz3xVOuxW0VspB4qhUx47uezju4JIx35g==",
       "dependencies": {
-        "@stablelib/base64": "^1.0.1",
-        "@tableland/evm": "^3.0.0",
-        "camelcase": "^6.3.0",
-        "ethers": "^5.6.9",
-        "siwe": "^2.0.5"
-      },
-      "engines": {
-        "node": ">=12.0.0"
+        "@tableland/evm": "^4.0.0-pre.1",
+        "@tableland/sqlparser": "^1.0.0-pre.0",
+        "camelize-ts": "^2.2.0",
+        "ethers": "^5.7.2"
       }
+    },
+    "node_modules/@tableland/sqlparser": {
+      "version": "1.0.0-pre.0",
+      "resolved": "https://registry.npmjs.org/@tableland/sqlparser/-/sqlparser-1.0.0-pre.0.tgz",
+      "integrity": "sha512-+VEca3XB+hQNKO2HiLeAYYNre/OrP8HsvRrpoisx+494JLAWab9vYVJ2MHd/L5PrQG9E9yClDoP2M0dAvc9VkQ=="
     },
     "node_modules/@tableland/validator": {
       "version": "0.0.2",
@@ -2112,11 +2071,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/apg-js": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/apg-js/-/apg-js-4.1.2.tgz",
-      "integrity": "sha512-2OALKUe82NLVPe4NTooom8NykWIa2D7YxO7jG1pgnYWnkfhTUriXpITmLvVD8k8TzDfa9G5O4y8rPe2/uUB1Bg=="
-    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -2194,6 +2148,18 @@
       "dev": true,
       "dependencies": {
         "async": "^2.4.0"
+      }
+    },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
+      "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/balanced-match": {
@@ -2447,11 +2413,20 @@
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
       "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
       "engines": {
         "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/camelize-ts": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/camelize-ts/-/camelize-ts-2.2.0.tgz",
+      "integrity": "sha512-6jMy83qFmNrJIMQXXU6Bi7VVkyl/nBVvoxcVsGRDA6R01pPZpnO/LaIcx6dijJjHbBA2G0uHY4Irk7LeA274NQ==",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
     "node_modules/catering": {
@@ -2856,27 +2831,32 @@
       }
     },
     "node_modules/es-abstract": {
-      "version": "1.20.5",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.5.tgz",
-      "integrity": "sha512-7h8MM2EQhsCA7pU/Nv78qOXFpD8Rhqd12gYiSJVkrH9+e8VuA8JlPJK/hQjjlLv6pJvx/z1iRFKzYb0XT/RuAQ==",
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.21.0.tgz",
+      "integrity": "sha512-GUGtW7eXQay0c+PRq0sGIKSdaBorfVqsCMhGHo4elP7YVqZu9nCZS4UkK4gv71gOWNMra/PaSKD3ao1oWExO0g==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
+        "es-set-tostringtag": "^2.0.0",
         "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
         "function.prototype.name": "^1.1.5",
         "get-intrinsic": "^1.1.3",
         "get-symbol-description": "^1.0.0",
+        "globalthis": "^1.0.3",
         "gopd": "^1.0.1",
         "has": "^1.0.3",
         "has-property-descriptors": "^1.0.0",
+        "has-proto": "^1.0.1",
         "has-symbols": "^1.0.3",
-        "internal-slot": "^1.0.3",
+        "internal-slot": "^1.0.4",
+        "is-array-buffer": "^3.0.0",
         "is-callable": "^1.2.7",
         "is-negative-zero": "^2.0.2",
         "is-regex": "^1.1.4",
         "is-shared-array-buffer": "^1.0.2",
         "is-string": "^1.0.7",
+        "is-typed-array": "^1.1.10",
         "is-weakref": "^1.0.2",
         "object-inspect": "^1.12.2",
         "object-keys": "^1.1.1",
@@ -2885,13 +2865,29 @@
         "safe-regex-test": "^1.0.0",
         "string.prototype.trimend": "^1.0.6",
         "string.prototype.trimstart": "^1.0.6",
-        "unbox-primitive": "^1.0.2"
+        "typed-array-length": "^1.0.4",
+        "unbox-primitive": "^1.0.2",
+        "which-typed-array": "^1.1.9"
       },
       "engines": {
         "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.1.tgz",
+      "integrity": "sha512-g3OMbtlwY3QewlqAiMLI47KywjWZoEytKr8pf6iTC8uJq5bIAH52Z9pnQ8pVL6whrCto53JZDuUIsifGeLorTg==",
+      "dev": true,
+      "dependencies": {
+        "get-intrinsic": "^1.1.3",
+        "has": "^1.0.3",
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/es-shim-unscopables": {
@@ -3672,9 +3668,9 @@
       "dev": true
     },
     "node_modules/fastq": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.14.0.tgz",
-      "integrity": "sha512-eR2D+V9/ExcbF9ls441yIuN6TI2ED1Y2ZcA5BmMtJsOkWOFRJQ0Jt0g1UwqXJJVAb+V+umH5Dfr8oh4EVP7VVg==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
+      "integrity": "sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==",
       "dev": true,
       "dependencies": {
         "reusify": "^1.0.4"
@@ -3766,6 +3762,15 @@
         "debug": {
           "optional": true
         }
+      }
+    },
+    "node_modules/for-each": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
+      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+      "dev": true,
+      "dependencies": {
+        "is-callable": "^1.1.3"
       }
     },
     "node_modules/fp-ts": {
@@ -3936,6 +3941,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globalthis": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.3.tgz",
+      "integrity": "sha512-sFdI5LyBiNTHjRd7cGPWapiHWMOXKyuBNX/cWJ3NfzrZQVa8GI/8cofCl74AOVqq9W5kNmguTIzJ/1s2gyI9wA==",
+      "dev": true,
+      "dependencies": {
+        "define-properties": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/globby": {
@@ -4249,6 +4269,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/has-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
+      "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/has-symbols": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
@@ -4389,9 +4421,9 @@
       }
     },
     "node_modules/immutable": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.2.1.tgz",
-      "integrity": "sha512-7WYV7Q5BTs0nlQm7tl92rDYYoyELLKHoDMBKhrxEoiV4mrfVdRz8hzPiYOzH7yWjzoVEamxRuAqhxL2PLRwZYQ==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.2.2.tgz",
+      "integrity": "sha512-fTMKDwtbvO5tldky9QZ2fMX7slR0mYpY5nbnFWYp0fOzDhHqhgIw9KoYgxLWsoNTS9ZHGauHj18DTyEw6BK3Og==",
       "dev": true
     },
     "node_modules/import-fresh": {
@@ -4471,6 +4503,20 @@
       "dev": true,
       "dependencies": {
         "fp-ts": "^1.0.0"
+      }
+    },
+    "node_modules/is-array-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.1.tgz",
+      "integrity": "sha512-ASfLknmY8Xa2XtB4wmbz13Wu202baeA18cJBCeCy0wXUHZF0IPyVEXqKEcd+t2fNSLLL1vC6k7lxZEojNbISXQ==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.3",
+        "is-typed-array": "^1.1.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-bigint": {
@@ -4725,6 +4771,25 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-typed-array": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.10.tgz",
+      "integrity": "sha512-PJqgEHiWZvMpaFZ3uTc8kHPM4+4ADTlDniuQL7cU/UDA0Ql7F70yGfHph3cLNe+c9toaigv+DFzTJKhc2CtO6A==",
+      "dev": true,
+      "dependencies": {
+        "available-typed-arrays": "^1.0.5",
+        "call-bind": "^1.0.2",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-unicode-supported": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
@@ -4794,9 +4859,9 @@
       "dev": true
     },
     "node_modules/json5": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
       "dev": true,
       "dependencies": {
         "minimist": "^1.2.0"
@@ -4815,9 +4880,9 @@
       }
     },
     "node_modules/keccak": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.2.tgz",
-      "integrity": "sha512-PyKKjkH53wDMLGrvmRGSNWgmSxZOUqbnXwKL9tmgbFYA1iAYqW21kfR7mZXV0MlESiefxQQE9X9fTa3X+2MPDQ==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.3.tgz",
+      "integrity": "sha512-JZrLIAJWuZxKbCilMpNz5Vj7Vtb4scDG3dMXLOsbzBmQGyjwE61BbW7bJkfKKCShXiQZt3T6sBgALRtmd+nZaQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -5233,9 +5298,9 @@
       "dev": true
     },
     "node_modules/node-gyp-build": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.5.0.tgz",
-      "integrity": "sha512-2iGbaQBV+ITgCz76ZEjmhUKAKVf7xfY1sRl4UiKQspfZMH2h06SyhNsnSVy50cwkFQDGLyif6m/6uFXHkOZ6rg==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.6.0.tgz",
+      "integrity": "sha512-NTZVKn9IylLwUzaKjkas1e4u2DLNcV4rdYagA4PWdPwW87Bi7z+BznyKSRwS/761tV/lzCGXplWsiaMjLqP2zQ==",
       "dev": true,
       "bin": {
         "node-gyp-build": "bin.js",
@@ -5527,6 +5592,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -5973,20 +6039,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/siwe": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/siwe/-/siwe-2.1.3.tgz",
-      "integrity": "sha512-d20jADr6MI6oWPDHg9bE+CBsUYkQQ2g4+ayCQ3QapAuYeE/dvFWI/7lwOOV21EuqZMmyrLVOSezgVoq0HAn8yw==",
-      "dependencies": {
-        "@spruceid/siwe-parser": "^2.0.2",
-        "@stablelib/random": "^1.0.1",
-        "uri-js": "^4.4.1",
-        "valid-url": "^1.0.9"
-      },
-      "peerDependencies": {
-        "ethers": "^5.5.1"
-      }
-    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -6361,6 +6413,20 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/typed-array-length": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.4.tgz",
+      "integrity": "sha512-KjZypGq+I/H7HI5HlOoGHkWUUGq+Q0TPhQurLbyrVrvnKTBgzLhIJ7j6J/XTQOi0d1RjyZ0wdas8bKs2p0x3Ng==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "for-each": "^0.3.3",
+        "is-typed-array": "^1.1.9"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/typescript": {
       "version": "4.9.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
@@ -6424,6 +6490,7 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
       }
@@ -6442,11 +6509,6 @@
       "bin": {
         "uuid": "dist/bin/uuid"
       }
-    },
-    "node_modules/valid-url": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/valid-url/-/valid-url-1.0.9.tgz",
-      "integrity": "sha512-QQDsV8OnSf5Uc30CKSwG9lnhMPe6exHtTXLRYX8uMwKENy640pU+2BgBL0LRbDh/eYRahNCS7aewCx0wf3NYVA=="
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -6473,6 +6535,26 @@
         "is-number-object": "^1.0.4",
         "is-string": "^1.0.5",
         "is-symbol": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.9.tgz",
+      "integrity": "sha512-w9c4xkx6mPidwp7180ckYWfMmvxpjlZuIudNtDf4N/tTAUB8VJbX25qZoAsrtGuYNnGw3pa0AXgbGKRB8/EceA==",
+      "dev": true,
+      "dependencies": {
+        "available-typed-arrays": "^1.0.5",
+        "call-bind": "^1.0.2",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "has-tostringtag": "^1.0.0",
+        "is-typed-array": "^1.1.10"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -7038,7 +7120,8 @@
     "@noble/hashes": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.2.tgz",
-      "integrity": "sha512-KYRCASVTv6aeUi1tsF8/vpyR7zpfs3FUzy2Jqm+MU+LmUKhQ0y2FpfwqkCcxSg2ua4GALJd8k2R76WxwZGbQpA=="
+      "integrity": "sha512-KYRCASVTv6aeUi1tsF8/vpyR7zpfs3FUzy2Jqm+MU+LmUKhQ0y2FpfwqkCcxSg2ua4GALJd8k2R76WxwZGbQpA==",
+      "dev": true
     },
     "@noble/secp256k1": {
       "version": "1.6.3",
@@ -7646,65 +7729,26 @@
         "tslib": "^1.9.3"
       }
     },
-    "@spruceid/siwe-parser": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@spruceid/siwe-parser/-/siwe-parser-2.0.2.tgz",
-      "integrity": "sha512-9WuA0ios2537cWYu39MMeH0O2KdrMKgKlOBUTWRTXQjCYu5B+mHCA0JkCbFaJ/0EjxoVIcYCXIW/DoPEpw+PqA==",
-      "requires": {
-        "@noble/hashes": "^1.1.2",
-        "apg-js": "^4.1.1",
-        "uri-js": "^4.4.1",
-        "valid-url": "^1.0.9"
-      }
-    },
-    "@stablelib/base64": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
-      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ=="
-    },
-    "@stablelib/binary": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@stablelib/binary/-/binary-1.0.1.tgz",
-      "integrity": "sha512-ClJWvmL6UBM/wjkvv/7m5VP3GMr9t0osr4yVgLZsLCOz4hGN9gIAFEqnJ0TsSMAN+n840nf2cHZnA5/KFqHC7Q==",
-      "requires": {
-        "@stablelib/int": "^1.0.1"
-      }
-    },
-    "@stablelib/int": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@stablelib/int/-/int-1.0.1.tgz",
-      "integrity": "sha512-byr69X/sDtDiIjIV6m4roLVWnNNlRGzsvxw+agj8CIEazqWGOQp2dTYgQhtyVXV9wpO6WyXRQUzLV/JRNumT2w=="
-    },
-    "@stablelib/random": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@stablelib/random/-/random-1.0.2.tgz",
-      "integrity": "sha512-rIsE83Xpb7clHPVRlBj8qNe5L8ISQOzjghYQm/dZ7VaM2KHYwMW5adjQjrzTZCchFnNCNhkwtnOBa9HTMJCI8w==",
-      "requires": {
-        "@stablelib/binary": "^1.0.1",
-        "@stablelib/wipe": "^1.0.1"
-      }
-    },
-    "@stablelib/wipe": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@stablelib/wipe/-/wipe-1.0.1.tgz",
-      "integrity": "sha512-WfqfX/eXGiAd3RJe4VU2snh/ZPwtSjLG4ynQ/vYzvghTh7dHFcI1wl+nrkWG6lGhukOxOsUHfv8dUXr58D0ayg=="
-    },
     "@tableland/evm": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@tableland/evm/-/evm-3.0.3.tgz",
-      "integrity": "sha512-Ci8QJubb6Z4ipPANALqAPQ9byh0tsRWZREej8QXGqLfHRqCAJfnMRTy2f47Oqq7IQ6Ajcy5holeUr9EtSmXNXA=="
+      "version": "4.0.0-pre.2",
+      "resolved": "https://registry.npmjs.org/@tableland/evm/-/evm-4.0.0-pre.2.tgz",
+      "integrity": "sha512-Cx+eVlovLvvUFkudlzBAMHh81J6LIuCNwDujNty+wgnpmkGJ/CJSP/gGe8VV/nchWyWkG3jPBaGRPa6Qi4xK2g=="
     },
     "@tableland/sdk": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/@tableland/sdk/-/sdk-3.1.5.tgz",
-      "integrity": "sha512-iq+1bsdxNDEGXFgEYAEYdPYjitkvqn4Y6r7B1eOUQmQ3GBErEaWUZfp9XI/CG6K/ZLmkpLettG9FF8FNNA52dA==",
+      "version": "4.0.0-pre.1",
+      "resolved": "https://registry.npmjs.org/@tableland/sdk/-/sdk-4.0.0-pre.1.tgz",
+      "integrity": "sha512-aE0Qco87Rr/LkHkypIaghHQexwVo1TFIA0+prDs6qc4k9UIyUnelBpz3xVOuxW0VspB4qhUx47uezju4JIx35g==",
       "requires": {
-        "@stablelib/base64": "^1.0.1",
-        "@tableland/evm": "^3.0.0",
-        "camelcase": "^6.3.0",
-        "ethers": "^5.6.9",
-        "siwe": "^2.0.5"
+        "@tableland/evm": "^4.0.0-pre.1",
+        "@tableland/sqlparser": "^1.0.0-pre.0",
+        "camelize-ts": "^2.2.0",
+        "ethers": "^5.7.2"
       }
+    },
+    "@tableland/sqlparser": {
+      "version": "1.0.0-pre.0",
+      "resolved": "https://registry.npmjs.org/@tableland/sqlparser/-/sqlparser-1.0.0-pre.0.tgz",
+      "integrity": "sha512-+VEca3XB+hQNKO2HiLeAYYNre/OrP8HsvRrpoisx+494JLAWab9vYVJ2MHd/L5PrQG9E9yClDoP2M0dAvc9VkQ=="
     },
     "@tableland/validator": {
       "version": "0.0.2",
@@ -8046,11 +8090,6 @@
         "picomatch": "^2.0.4"
       }
     },
-    "apg-js": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/apg-js/-/apg-js-4.1.2.tgz",
-      "integrity": "sha512-2OALKUe82NLVPe4NTooom8NykWIa2D7YxO7jG1pgnYWnkfhTUriXpITmLvVD8k8TzDfa9G5O4y8rPe2/uUB1Bg=="
-    },
     "argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -8111,6 +8150,12 @@
       "requires": {
         "async": "^2.4.0"
       }
+    },
+    "available-typed-arrays": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
+      "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
+      "dev": true
     },
     "balanced-match": {
       "version": "1.0.2",
@@ -8310,7 +8355,13 @@
     "camelcase": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
-      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA=="
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true
+    },
+    "camelize-ts": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/camelize-ts/-/camelize-ts-2.2.0.tgz",
+      "integrity": "sha512-6jMy83qFmNrJIMQXXU6Bi7VVkyl/nBVvoxcVsGRDA6R01pPZpnO/LaIcx6dijJjHbBA2G0uHY4Irk7LeA274NQ=="
     },
     "catering": {
       "version": "2.1.1",
@@ -8620,27 +8671,32 @@
       "dev": true
     },
     "es-abstract": {
-      "version": "1.20.5",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.5.tgz",
-      "integrity": "sha512-7h8MM2EQhsCA7pU/Nv78qOXFpD8Rhqd12gYiSJVkrH9+e8VuA8JlPJK/hQjjlLv6pJvx/z1iRFKzYb0XT/RuAQ==",
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.21.0.tgz",
+      "integrity": "sha512-GUGtW7eXQay0c+PRq0sGIKSdaBorfVqsCMhGHo4elP7YVqZu9nCZS4UkK4gv71gOWNMra/PaSKD3ao1oWExO0g==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
+        "es-set-tostringtag": "^2.0.0",
         "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
         "function.prototype.name": "^1.1.5",
         "get-intrinsic": "^1.1.3",
         "get-symbol-description": "^1.0.0",
+        "globalthis": "^1.0.3",
         "gopd": "^1.0.1",
         "has": "^1.0.3",
         "has-property-descriptors": "^1.0.0",
+        "has-proto": "^1.0.1",
         "has-symbols": "^1.0.3",
-        "internal-slot": "^1.0.3",
+        "internal-slot": "^1.0.4",
+        "is-array-buffer": "^3.0.0",
         "is-callable": "^1.2.7",
         "is-negative-zero": "^2.0.2",
         "is-regex": "^1.1.4",
         "is-shared-array-buffer": "^1.0.2",
         "is-string": "^1.0.7",
+        "is-typed-array": "^1.1.10",
         "is-weakref": "^1.0.2",
         "object-inspect": "^1.12.2",
         "object-keys": "^1.1.1",
@@ -8649,7 +8705,20 @@
         "safe-regex-test": "^1.0.0",
         "string.prototype.trimend": "^1.0.6",
         "string.prototype.trimstart": "^1.0.6",
-        "unbox-primitive": "^1.0.2"
+        "typed-array-length": "^1.0.4",
+        "unbox-primitive": "^1.0.2",
+        "which-typed-array": "^1.1.9"
+      }
+    },
+    "es-set-tostringtag": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.1.tgz",
+      "integrity": "sha512-g3OMbtlwY3QewlqAiMLI47KywjWZoEytKr8pf6iTC8uJq5bIAH52Z9pnQ8pVL6whrCto53JZDuUIsifGeLorTg==",
+      "dev": true,
+      "requires": {
+        "get-intrinsic": "^1.1.3",
+        "has": "^1.0.3",
+        "has-tostringtag": "^1.0.0"
       }
     },
     "es-shim-unscopables": {
@@ -9247,9 +9316,9 @@
       "dev": true
     },
     "fastq": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.14.0.tgz",
-      "integrity": "sha512-eR2D+V9/ExcbF9ls441yIuN6TI2ED1Y2ZcA5BmMtJsOkWOFRJQ0Jt0g1UwqXJJVAb+V+umH5Dfr8oh4EVP7VVg==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
+      "integrity": "sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==",
       "dev": true,
       "requires": {
         "reusify": "^1.0.4"
@@ -9310,6 +9379,15 @@
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
       "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
       "dev": true
+    },
+    "for-each": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
+      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+      "dev": true,
+      "requires": {
+        "is-callable": "^1.1.3"
+      }
     },
     "fp-ts": {
       "version": "1.19.3",
@@ -9430,6 +9508,15 @@
       "dev": true,
       "requires": {
         "type-fest": "^0.20.2"
+      }
+    },
+    "globalthis": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.3.tgz",
+      "integrity": "sha512-sFdI5LyBiNTHjRd7cGPWapiHWMOXKyuBNX/cWJ3NfzrZQVa8GI/8cofCl74AOVqq9W5kNmguTIzJ/1s2gyI9wA==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3"
       }
     },
     "globby": {
@@ -9670,6 +9757,12 @@
         "get-intrinsic": "^1.1.1"
       }
     },
+    "has-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
+      "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
+      "dev": true
+    },
     "has-symbols": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
@@ -9766,9 +9859,9 @@
       "dev": true
     },
     "immutable": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.2.1.tgz",
-      "integrity": "sha512-7WYV7Q5BTs0nlQm7tl92rDYYoyELLKHoDMBKhrxEoiV4mrfVdRz8hzPiYOzH7yWjzoVEamxRuAqhxL2PLRwZYQ==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.2.2.tgz",
+      "integrity": "sha512-fTMKDwtbvO5tldky9QZ2fMX7slR0mYpY5nbnFWYp0fOzDhHqhgIw9KoYgxLWsoNTS9ZHGauHj18DTyEw6BK3Og==",
       "dev": true
     },
     "import-fresh": {
@@ -9830,6 +9923,17 @@
       "dev": true,
       "requires": {
         "fp-ts": "^1.0.0"
+      }
+    },
+    "is-array-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.1.tgz",
+      "integrity": "sha512-ASfLknmY8Xa2XtB4wmbz13Wu202baeA18cJBCeCy0wXUHZF0IPyVEXqKEcd+t2fNSLLL1vC6k7lxZEojNbISXQ==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.3",
+        "is-typed-array": "^1.1.10"
       }
     },
     "is-bigint": {
@@ -9985,6 +10089,19 @@
         "has-symbols": "^1.0.2"
       }
     },
+    "is-typed-array": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.10.tgz",
+      "integrity": "sha512-PJqgEHiWZvMpaFZ3uTc8kHPM4+4ADTlDniuQL7cU/UDA0Ql7F70yGfHph3cLNe+c9toaigv+DFzTJKhc2CtO6A==",
+      "dev": true,
+      "requires": {
+        "available-typed-arrays": "^1.0.5",
+        "call-bind": "^1.0.2",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "has-tostringtag": "^1.0.0"
+      }
+    },
     "is-unicode-supported": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
@@ -10038,9 +10155,9 @@
       "dev": true
     },
     "json5": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
       "dev": true,
       "requires": {
         "minimist": "^1.2.0"
@@ -10056,9 +10173,9 @@
       }
     },
     "keccak": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.2.tgz",
-      "integrity": "sha512-PyKKjkH53wDMLGrvmRGSNWgmSxZOUqbnXwKL9tmgbFYA1iAYqW21kfR7mZXV0MlESiefxQQE9X9fTa3X+2MPDQ==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.3.tgz",
+      "integrity": "sha512-JZrLIAJWuZxKbCilMpNz5Vj7Vtb4scDG3dMXLOsbzBmQGyjwE61BbW7bJkfKKCShXiQZt3T6sBgALRtmd+nZaQ==",
       "dev": true,
       "requires": {
         "node-addon-api": "^2.0.0",
@@ -10388,9 +10505,9 @@
       "dev": true
     },
     "node-gyp-build": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.5.0.tgz",
-      "integrity": "sha512-2iGbaQBV+ITgCz76ZEjmhUKAKVf7xfY1sRl4UiKQspfZMH2h06SyhNsnSVy50cwkFQDGLyif6m/6uFXHkOZ6rg==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.6.0.tgz",
+      "integrity": "sha512-NTZVKn9IylLwUzaKjkas1e4u2DLNcV4rdYagA4PWdPwW87Bi7z+BznyKSRwS/761tV/lzCGXplWsiaMjLqP2zQ==",
       "dev": true
     },
     "normalize-path": {
@@ -10586,7 +10703,8 @@
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true
     },
     "qs": {
       "version": "6.11.0",
@@ -10884,17 +11002,6 @@
         "object-inspect": "^1.9.0"
       }
     },
-    "siwe": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/siwe/-/siwe-2.1.3.tgz",
-      "integrity": "sha512-d20jADr6MI6oWPDHg9bE+CBsUYkQQ2g4+ayCQ3QapAuYeE/dvFWI/7lwOOV21EuqZMmyrLVOSezgVoq0HAn8yw==",
-      "requires": {
-        "@spruceid/siwe-parser": "^2.0.2",
-        "@stablelib/random": "^1.0.1",
-        "uri-js": "^4.4.1",
-        "valid-url": "^1.0.9"
-      }
-    },
     "slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -11182,6 +11289,17 @@
       "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
       "dev": true
     },
+    "typed-array-length": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.4.tgz",
+      "integrity": "sha512-KjZypGq+I/H7HI5HlOoGHkWUUGq+Q0TPhQurLbyrVrvnKTBgzLhIJ7j6J/XTQOi0d1RjyZ0wdas8bKs2p0x3Ng==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "for-each": "^0.3.3",
+        "is-typed-array": "^1.1.9"
+      }
+    },
     "typescript": {
       "version": "4.9.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
@@ -11226,6 +11344,7 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
       "requires": {
         "punycode": "^2.1.0"
       }
@@ -11241,11 +11360,6 @@
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
       "dev": true
-    },
-    "valid-url": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/valid-url/-/valid-url-1.0.9.tgz",
-      "integrity": "sha512-QQDsV8OnSf5Uc30CKSwG9lnhMPe6exHtTXLRYX8uMwKENy640pU+2BgBL0LRbDh/eYRahNCS7aewCx0wf3NYVA=="
     },
     "which": {
       "version": "2.0.2",
@@ -11266,6 +11380,20 @@
         "is-number-object": "^1.0.4",
         "is-string": "^1.0.5",
         "is-symbol": "^1.0.3"
+      }
+    },
+    "which-typed-array": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.9.tgz",
+      "integrity": "sha512-w9c4xkx6mPidwp7180ckYWfMmvxpjlZuIudNtDf4N/tTAUB8VJbX25qZoAsrtGuYNnGw3pa0AXgbGKRB8/EceA==",
+      "dev": true,
+      "requires": {
+        "available-typed-arrays": "^1.0.5",
+        "call-bind": "^1.0.2",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "has-tostringtag": "^1.0.0",
+        "is-typed-array": "^1.1.10"
       }
     },
     "word-wrap": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "MIT",
       "dependencies": {
         "@tableland/sdk": "^4.0.0-pre.1",
-        "@tableland/validator": "^0.0.2",
+        "@tableland/validator": "^0.0.3",
         "cross-spawn": "^7.0.3",
         "enquirer": "^2.3.6",
         "ethers": "^5.7.2",
@@ -1591,9 +1591,9 @@
       "integrity": "sha512-+VEca3XB+hQNKO2HiLeAYYNre/OrP8HsvRrpoisx+494JLAWab9vYVJ2MHd/L5PrQG9E9yClDoP2M0dAvc9VkQ=="
     },
     "node_modules/@tableland/validator": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@tableland/validator/-/validator-0.0.2.tgz",
-      "integrity": "sha512-CykQIihLfujH5d+S6we2Kg86gu2MLaTFLorBiXe4Tgq3QjovSLjPk5ahR0VKy50L8Kvk8U2MUErz2V9Mw7Hy1A=="
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@tableland/validator/-/validator-0.0.3.tgz",
+      "integrity": "sha512-Zzpq96ofuC46uoNj7JwBNxMKoOoxlbVy3rIpFIuyQUagcWlLRumk/JCf4SeWNNEpGu8Y4d+hWsue5uxtKl1Nog=="
     },
     "node_modules/@types/async-eventemitter": {
       "version": "0.2.1",
@@ -7751,9 +7751,9 @@
       "integrity": "sha512-+VEca3XB+hQNKO2HiLeAYYNre/OrP8HsvRrpoisx+494JLAWab9vYVJ2MHd/L5PrQG9E9yClDoP2M0dAvc9VkQ=="
     },
     "@tableland/validator": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@tableland/validator/-/validator-0.0.2.tgz",
-      "integrity": "sha512-CykQIihLfujH5d+S6we2Kg86gu2MLaTFLorBiXe4Tgq3QjovSLjPk5ahR0VKy50L8Kvk8U2MUErz2V9Mw7Hy1A=="
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@tableland/validator/-/validator-0.0.3.tgz",
+      "integrity": "sha512-Zzpq96ofuC46uoNj7JwBNxMKoOoxlbVy3rIpFIuyQUagcWlLRumk/JCf4SeWNNEpGu8Y4d+hWsue5uxtKl1Nog=="
     },
     "@types/async-eventemitter": {
       "version": "0.2.1",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "local-tableland": "dist/esm/up.js"
   },
   "dependencies": {
-    "@tableland/sdk": "^3.1.5",
+    "@tableland/sdk": "^4.0.0-pre.1",
     "@tableland/validator": "^0.0.2",
     "cross-spawn": "^7.0.3",
     "enquirer": "^2.3.6",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   },
   "dependencies": {
     "@tableland/sdk": "^4.0.0-pre.1",
-    "@tableland/validator": "^0.0.2",
+    "@tableland/validator": "^0.0.3",
     "cross-spawn": "^7.0.3",
     "enquirer": "^2.3.6",
     "ethers": "^5.7.2",

--- a/registry/package-lock.json
+++ b/registry/package-lock.json
@@ -10,7 +10,7 @@
         "@nomiclabs/hardhat-ethers": "^2.2.0",
         "@openzeppelin/contracts-upgradeable": "^4.8.0-rc.1",
         "@openzeppelin/hardhat-upgrades": "^1.21.0",
-        "@tableland/evm": "3.0.1-next3.0.2",
+        "@tableland/evm": "^4.0.0-pre.2",
         "erc721a-upgradeable": "^4.2.2",
         "hardhat": "^2.12.0"
       }
@@ -1602,9 +1602,9 @@
       }
     },
     "node_modules/@tableland/evm": {
-      "version": "3.0.1-next3.0.2",
-      "resolved": "https://registry.npmjs.org/@tableland/evm/-/evm-3.0.1-next3.0.2.tgz",
-      "integrity": "sha512-sdf72rnk0PH7TpoCfHN+FvGGVWkt/NeW70SjE/fjWKBwg4ULakWYxxalbBs2o0hoHtRq2EzXsk/FlUSgyje/9A==",
+      "version": "4.0.0-pre.2",
+      "resolved": "https://registry.npmjs.org/@tableland/evm/-/evm-4.0.0-pre.2.tgz",
+      "integrity": "sha512-Cx+eVlovLvvUFkudlzBAMHh81J6LIuCNwDujNty+wgnpmkGJ/CJSP/gGe8VV/nchWyWkG3jPBaGRPa6Qi4xK2g==",
       "engines": {
         "node": ">=14.0.0"
       }
@@ -9479,9 +9479,9 @@
       }
     },
     "@tableland/evm": {
-      "version": "3.0.1-next3.0.2",
-      "resolved": "https://registry.npmjs.org/@tableland/evm/-/evm-3.0.1-next3.0.2.tgz",
-      "integrity": "sha512-sdf72rnk0PH7TpoCfHN+FvGGVWkt/NeW70SjE/fjWKBwg4ULakWYxxalbBs2o0hoHtRq2EzXsk/FlUSgyje/9A=="
+      "version": "4.0.0-pre.2",
+      "resolved": "https://registry.npmjs.org/@tableland/evm/-/evm-4.0.0-pre.2.tgz",
+      "integrity": "sha512-Cx+eVlovLvvUFkudlzBAMHh81J6LIuCNwDujNty+wgnpmkGJ/CJSP/gGe8VV/nchWyWkG3jPBaGRPa6Qi4xK2g=="
     },
     "@tsconfig/node10": {
       "version": "1.0.9",

--- a/registry/package.json
+++ b/registry/package.json
@@ -2,11 +2,11 @@
   "name": "local-tableland-registry",
   "dependencies": {
     "@nomicfoundation/hardhat-toolbox": "^2.0.0",
-    "hardhat": "^2.12.0",
     "@nomiclabs/hardhat-ethers": "^2.2.0",
     "@openzeppelin/contracts-upgradeable": "^4.8.0-rc.1",
     "@openzeppelin/hardhat-upgrades": "^1.21.0",
-    "@tableland/evm": "3.0.1-next3.0.2",
-    "erc721a-upgradeable": "^4.2.2"
+    "@tableland/evm": "^4.0.0-pre.2",
+    "erc721a-upgradeable": "^4.2.2",
+    "hardhat": "^2.12.0"
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -15,7 +15,7 @@ import {
   pipeNamedSubprocess,
   waitForReady,
   getAccounts,
-  getConnection,
+  getDatabase,
   logSync,
   isWindows,
   inDebugMode,
@@ -231,5 +231,5 @@ class LocalTableland {
   }
 }
 
-export { LocalTableland, getAccounts, getConnection };
+export { LocalTableland, getAccounts, getDatabase };
 export type { Config };

--- a/src/util.ts
+++ b/src/util.ts
@@ -7,6 +7,8 @@ import { getDefaultProvider, Wallet } from "ethers";
 import {
   getBaseUrl,
   Database,
+  Registry,
+  Validator,
   overrideDefaults,
   getChainId,
 } from "@tableland/sdk";
@@ -284,11 +286,23 @@ const hardhatAccounts = [
   "df57089febbacf7ba0bc227dafbffa9fc08a93fdc68e1e42411a14efcf23656e",
 ];
 
-export const getConnection = function (account: Wallet): Database {
+export const getDatabase = function (account: Wallet): Database {
   return new Database({
     signer: account,
     baseUrl: getBaseUrl("local-tableland"),
     autoWait: true,
+  });
+};
+
+export const getRegistry = function (account: Wallet): Registry {
+  return new Registry({
+    signer: account,
+  });
+};
+
+export const getValidator = function (baseUrl?: string): Validator {
+  return new Validator({
+    baseUrl: baseUrl || getBaseUrl("local-tableland"),
   });
 };
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -4,12 +4,22 @@ import { EventEmitter } from "node:events";
 import { Readable } from "node:stream";
 import { ChildProcess, SpawnSyncReturns } from "node:child_process";
 import { getDefaultProvider, Wallet } from "ethers";
-import { connect, Connection } from "@tableland/sdk";
+import {
+  getBaseUrl,
+  Database,
+  overrideDefaults,
+  getChainId,
+} from "@tableland/sdk";
 import { chalk } from "./chalk.js";
 
 // NOTE: We are creating this file in the prebuild.sh script so that we can support cjs and esm
 import { getDirname } from "./get-dirname.js";
 const _dirname = getDirname();
+
+// The SDK does not know about the local-tableland contract
+overrideDefaults(getChainId("local-tableland"), {
+  contractAddress: "0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512",
+});
 
 export type ConfigDescriptor = {
   name: string;
@@ -274,8 +284,12 @@ const hardhatAccounts = [
   "df57089febbacf7ba0bc227dafbffa9fc08a93fdc68e1e42411a14efcf23656e",
 ];
 
-export const getConnection = function (account: Wallet): Connection {
-  return connect({ signer: account, chain: "local-tableland" });
+export const getConnection = function (account: Wallet): Database {
+  return new Database({
+    signer: account,
+    baseUrl: getBaseUrl("local-tableland"),
+    autoWait: true,
+  });
 };
 
 export const getAccounts = function (): Wallet[] {

--- a/src/validators.ts
+++ b/src/validators.ts
@@ -120,6 +120,11 @@ class ValidatorDev {
     spawnSync("make", ["local-down"], {
       cwd: join(this.validatorDir, "docker"),
     });
+    // If this Class is imported and run by a test runner then the ChildProcess instances are
+    // sub-processes of a ChildProcess instance which means in order to kill them in a way that
+    // enables graceful shut down they have to run in detached mode and be killed by the pid
+    // @ts-ignore
+    process.kill(-this.process.pid);
   }
 
   cleanup() {

--- a/test/e2e.test.mjs
+++ b/test/e2e.test.mjs
@@ -1,5 +1,4 @@
 import chai from "chai";
-// import { connect } from "@tableland/sdk";
 import {
   getAccounts,
   getDatabase,
@@ -15,7 +14,6 @@ describe("Validator, Chain, and SDK work end to end", function () {
   const accounts = getAccounts();
   const lt = new LocalTableland({
     silent: true,
-    // validatorDir: "../go-tableland",
   });
 
   // These tests take a bit longer than normal since we are running them against an actual network
@@ -33,9 +31,6 @@ describe("Validator, Chain, and SDK work end to end", function () {
     const signer = accounts[1];
     const db = getDatabase(signer);
 
-    // TODO: using exec here, there's quite a few methods that can be used for creating a table,
-    //       and they are scattered throughout these tests atm. We can potentially build in specific
-    //       tests for each method in the future.
     // `key` is a reserved word in sqlite.
     const res = await db.exec(
       `CREATE TABLE test_create_read (keyy TEXT, val TEXT);`

--- a/test/e2e.test.mjs
+++ b/test/e2e.test.mjs
@@ -1,15 +1,21 @@
 import chai from "chai";
 // import { connect } from "@tableland/sdk";
-import { getAccounts, getConnection } from "../dist/esm/util.js";
+import {
+  getAccounts,
+  getDatabase,
+  getRegistry,
+  getValidator,
+} from "../dist/esm/util.js";
 import { LocalTableland } from "../dist/esm/main.js";
 
 const expect = chai.expect;
+const localTablelandChainId = 31337;
 
 describe("Validator, Chain, and SDK work end to end", function () {
   const accounts = getAccounts();
   const lt = new LocalTableland({
-    silent: false,
-    validatorDir: "../go-tableland",
+    silent: true,
+    // validatorDir: "../go-tableland",
   });
 
   // These tests take a bit longer than normal since we are running them against an actual network
@@ -25,69 +31,63 @@ describe("Validator, Chain, and SDK work end to end", function () {
 
   it("creates a table that can be read from", async function () {
     const signer = accounts[1];
-    const tableland = getConnection(signer);
+    const db = getDatabase(signer);
 
     // TODO: using exec here, there's quite a few methods that can be used for creating a table,
     //       and they are scattered throughout these tests atm. We can potentially build in specific
     //       tests for each method in the future.
     // `key` is a reserved word in sqlite.
-    const res = await tableland.exec(
+    const res = await db.exec(
       `CREATE TABLE test_create_read (keyy TEXT, val TEXT);`
     );
 
-    const data = await tableland
-      .prepare(`SELECT * FROM ${res.meta.txn.name};`)
-      .all();
+    const data = await db.prepare(`SELECT * FROM ${res.meta.txn.name};`).all();
     expect(data.results).to.eql([]);
   });
 
   it("create a table that can be written to", async function () {
     this.timeout(50000);
     const signer = accounts[1];
-    const tableland = getConnection(signer);
+    const db = getDatabase(signer);
 
-    const { meta: createMetadata } = await tableland
+    const { meta: createMetadata } = await db
       .prepare("CREATE TABLE test_create_write (keyy TEXT, val TEXT);")
       .run();
 
     const tableName = createMetadata.txn?.name ?? "";
     expect(tableName).to.match(/^test_create_write_31337_\d+$/);
 
-    const insertRes = await tableland
+    const insertRes = await db
       .prepare(`INSERT INTO ${tableName} (keyy, val) VALUES ('tree', 'aspen');`)
       .run();
 
     expect(insertRes.success).to.eql(true);
     expect(typeof insertRes.meta.duration).to.eql("number");
 
-    const readRes = await tableland
-      .prepare(`SELECT * FROM ${tableName};`)
-      .all();
+    const readRes = await db.prepare(`SELECT * FROM ${tableName};`).all();
 
     expect(readRes.results).to.eql([{ keyy: "tree", val: "aspen" }]);
   });
 
   it("table cannot be written to unless caller is allowed", async function () {
     const signer = accounts[1];
-    const tableland = getConnection(signer);
+    const db = getDatabase(signer);
 
-    const { meta: createMetadata } = await tableland
+    const { meta: createMetadata } = await db
       .prepare("CREATE TABLE test_not_allowed (keyy TEXT, val TEXT);")
       .run();
     const queryableName = createMetadata.txn?.name ?? "";
 
-    const data = await tableland
-      .prepare(`SELECT * FROM ${queryableName};`)
-      .all();
+    const data = await db.prepare(`SELECT * FROM ${queryableName};`).all();
 
     expect(data.results).to.eql([]);
 
     const signer2 = accounts[2];
-    const tableland2 = getConnection(signer2);
+    const db2 = getDatabase(signer2);
 
     await expect(
       (async function () {
-        await tableland2
+        await db2
           .prepare(
             `INSERT INTO ${queryableName} (keyy, val) VALUES ('tree', 'aspen')`
           )
@@ -99,22 +99,20 @@ describe("Validator, Chain, and SDK work end to end", function () {
       "ALL_ERROR"
     );
 
-    const data2 = await tableland2
-      .prepare(`SELECT * FROM ${queryableName};`)
-      .all();
+    const data2 = await db2.prepare(`SELECT * FROM ${queryableName};`).all();
     expect(data2.results).to.eql([]);
   });
 
   it("create a table can have a row deleted", async function () {
     const signer = accounts[1];
-    const tableland = getConnection(signer);
+    const db = getDatabase(signer);
 
-    const { meta: createMetadata } = await tableland
+    const { meta: createMetadata } = await db
       .prepare("CREATE TABLE test_create_delete (keyy TEXT, val TEXT);")
       .run();
     const queryableName = createMetadata.txn?.name ?? "";
 
-    const write1 = await tableland
+    const write1 = await db
       .prepare(
         `INSERT INTO ${queryableName} (keyy, val) VALUES ('tree', 'aspen')`
       )
@@ -122,7 +120,7 @@ describe("Validator, Chain, and SDK work end to end", function () {
 
     expect(typeof write1.meta.txn.transactionHash).to.eql("string");
 
-    const write2 = await tableland
+    const write2 = await db
       .prepare(
         `INSERT INTO ${queryableName} (keyy, val) VALUES ('tree', 'pine')`
       )
@@ -130,20 +128,16 @@ describe("Validator, Chain, and SDK work end to end", function () {
 
     expect(typeof write2.meta.txn.transactionHash).to.eql("string");
 
-    const data = await tableland
-      .prepare(`SELECT * FROM ${queryableName};`)
-      .all();
+    const data = await db.prepare(`SELECT * FROM ${queryableName};`).all();
     expect(data.results.length).to.eql(2);
 
-    const delete1 = await tableland
+    const delete1 = await db
       .prepare(`DELETE FROM ${queryableName} WHERE val = 'pine';`)
       .all();
 
     expect(typeof delete1.meta.txn.transactionHash).to.eql("string");
 
-    const data2 = await tableland
-      .prepare(`SELECT * FROM ${queryableName};`)
-      .all();
+    const data2 = await db.prepare(`SELECT * FROM ${queryableName};`).all();
     await expect(data2.results.length).to.eql(1);
   }, 30000);
 
@@ -151,20 +145,20 @@ describe("Validator, Chain, and SDK work end to end", function () {
   //       assuming that is still appropriate
   it("read via `raw` method returns data with `table` output", async function () {
     const signer = accounts[1];
-    const tableland = getConnection(signer);
+    const db = getDatabase(signer);
 
-    const { meta: createMetadata } = await tableland
+    const { meta: createMetadata } = await db
       .prepare("CREATE TABLE test_read (keyy TEXT, val TEXT);")
       .run();
     const queryableName = createMetadata.txn?.name ?? "";
 
-    await tableland
+    await db
       .prepare(
         `INSERT INTO ${queryableName} (keyy, val) VALUES ('tree', 'aspen')`
       )
       .all();
 
-    const data = await tableland
+    const data = await db
       .prepare(`SELECT * FROM ${queryableName};`, {
         output: "table",
       })
@@ -175,26 +169,26 @@ describe("Validator, Chain, and SDK work end to end", function () {
 
   it("count rows in a table", async function () {
     const signer = accounts[1];
-    const tableland = getConnection(signer);
+    const db = getDatabase(signer);
 
-    const { meta: createMetadata } = await tableland
+    const { meta: createMetadata } = await db
       .prepare("CREATE TABLE test_count (keyy TEXT, val TEXT);")
       .run();
     const queryableName = createMetadata.txn?.name ?? "";
 
-    await tableland
+    await db
       .prepare(
         `INSERT INTO ${queryableName} (keyy, val) VALUES ('tree', 'aspen')`
       )
       .all();
 
-    await tableland
+    await db
       .prepare(
         `INSERT INTO ${queryableName} (keyy, val) VALUES ('tree', 'pine')`
       )
       .all();
 
-    const data = await tableland
+    const data = await db
       .prepare(`SELECT COUNT(*) FROM ${queryableName};`)
       .all();
 
@@ -203,72 +197,68 @@ describe("Validator, Chain, and SDK work end to end", function () {
 
   it("read a single row with `first` method", async function () {
     const signer = accounts[1];
-    const tableland = getConnection(signer);
+    const db = getDatabase(signer);
 
-    const { meta: createMetadata } = await tableland
+    const { meta: createMetadata } = await db
       .prepare("CREATE TABLE test_read (keyy TEXT, val TEXT);")
       .run();
     const queryableName = createMetadata.txn?.name ?? "";
 
-    await tableland
+    await db
       .prepare(
         `INSERT INTO ${queryableName} (keyy, val) VALUES ('tree', 'aspen')`
       )
       .all();
 
-    await tableland
+    await db
       .prepare(
         `INSERT INTO ${queryableName} (keyy, val) VALUES ('tree', 'pine')`
       )
       .all();
 
-    const data = await tableland
-      .prepare(`SELECT * FROM ${queryableName};`)
-      .first();
+    const data = await db.prepare(`SELECT * FROM ${queryableName};`).first();
 
     expect(data).to.eql({ keyy: "tree", val: "aspen" });
   });
 
-  // TODO: what happend to `list`? is it gone or replaced?
-  it.skip("list an account's tables", async function () {
+  it("list an account's tables", async function () {
     const signer = accounts[1];
-    const tableland = getConnection(signer);
+    const db = getDatabase(signer);
+    const registry = getRegistry(signer);
 
-    const { meta: createMetadata } = await tableland
+    const { meta: createMetadata } = await db
       .prepare("CREATE TABLE test_create_list (keyy TEXT, val TEXT);")
       .run();
-    const queryableName = createMetadata.txn?.name ?? "";
+    const tableId = createMetadata.txn?.tableId ?? "";
 
-    const tablesMeta = await tableland.list();
+    const tablesMeta = await registry.listTables();
 
     expect(Array.isArray(tablesMeta)).to.eql(true);
-    const table = tablesMeta.find((table) => table.name === queryableName);
+    const table = tablesMeta.find((table) => table.tableId === tableId);
 
     expect(typeof table).to.equal("object");
-    expect(table.controller).to.eql(accounts[1].address);
+    expect(table.chainId).to.eql(localTablelandChainId);
   });
 
   it("write statement validates table name prefix", async function () {
     const signer = accounts[1];
-    const tableland = getConnection(signer);
+    const db = getDatabase(signer);
 
     const prefix1 = "test_direct_invalid_write";
-    await tableland
-      .prepare(`CREATE TABLE ${prefix1} (keyy TEXT, val TEXT);`)
-      .run();
+    await db.prepare(`CREATE TABLE ${prefix1} (keyy TEXT, val TEXT);`).run();
 
-    const { meta: createMetadata2 } = await tableland
+    const { meta: createMetadata2 } = await db
       .prepare("CREATE TABLE test_direct_invalid_write2 (keyy TEXT, val TEXT);")
       .run();
     const tableId2 = createMetadata2.txn?.tableId ?? "";
 
     // both tables owned by the same account
     // the prefix is for the first table, but id is for second table
-    const invalidName = `${prefix1}_31337_${tableId2}`;
+    const invalidName = `${prefix1}_${localTablelandChainId}_${tableId2}`;
 
     await expect(
       (async function () {
-        await tableland
+        await db
           .prepare(
             `INSERT INTO ${invalidName} (keyy, val) VALUES ('tree', 'aspen')`
           )
@@ -283,19 +273,17 @@ describe("Validator, Chain, and SDK work end to end", function () {
 
   it("write statement validates table ID", async function () {
     const signer = accounts[1];
-    const tableland = getConnection(signer);
+    const db = getDatabase(signer);
 
     const prefix = "test_direct_invalid_id_write";
-    await tableland
-      .prepare(`CREATE TABLE ${prefix} (keyy TEXT, val TEXT);`)
-      .run();
+    await db.prepare(`CREATE TABLE ${prefix} (keyy TEXT, val TEXT);`).run();
 
     // the tableId 0 does not exist since we start with tableId == 1
-    const queryableName = `${prefix}_31337_0`;
+    const queryableName = `${prefix}_${localTablelandChainId}_0`;
 
     await expect(
       (async function () {
-        await tableland
+        await db
           .prepare(
             `INSERT INTO ${queryableName} (keyy, val) VALUES ('tree', 'aspen')`
           )
@@ -308,131 +296,112 @@ describe("Validator, Chain, and SDK work end to end", function () {
     );
   });
 
-  // TODO: how do we set controller in the new SDK?
-  it.skip("allows setting controller", async function () {
+  it("allows setting controller", async function () {
     const signer = accounts[1];
-    const tableland = getConnection(signer);
+    const db = getDatabase(signer);
+    const registry = getRegistry(signer);
 
-    const { meta: createMetadata } = await tableland
+    const { meta: createMetadata } = await db
       .prepare("CREATE TABLE test_set_controller (keyy TEXT, val TEXT);")
       .run();
-    const queryableName = createMetadata.txn?.name ?? "";
+    const tableName = createMetadata.txn?.name ?? "";
 
-    // Set the controller to Hardhat #7
-    const { hash } = await tableland.setController(
-      "0x14dC79964da2C08b23698B3D3cc7Ca32193d9955",
-      queryableName
-    );
+    const { hash } = await registry.setController({
+      // Set the controller to Hardhat #7
+      controller: "0x14dC79964da2C08b23698B3D3cc7Ca32193d9955",
+      tableName,
+    });
 
     expect(typeof hash).to.eql("string");
     expect(hash.length).to.eql(66);
   });
 
-  // TODO: how do we get controller in the new SDK?
-  it.skip("get controller returns an address", async function () {
+  it("get controller returns an address", async function () {
     const signer = accounts[1];
-    const tableland = getConnection(signer);
+    const db = getDatabase(signer);
+    const registry = getRegistry(signer);
 
-    const { meta: createMetadata } = await tableland
+    const { meta: createMetadata } = await db
       .prepare("CREATE TABLE test_create_getcontroller (keyy TEXT, val TEXT);")
       .run();
-    const queryableName = createMetadata.txn?.name ?? "";
+    const tableName = createMetadata.txn?.name ?? "";
 
     // Hardhat #7
     const controllerAddress = "0x14dC79964da2C08b23698B3D3cc7Ca32193d9955";
 
-    const { hash } = await tableland.setController(
-      controllerAddress,
-      queryableName
-    );
+    const { hash } = await registry.setController({
+      controller: controllerAddress,
+      tableName,
+    });
 
     expect(typeof hash).to.eql("string");
     expect(hash.length).to.eql(66);
 
-    const controller = await tableland.getController(queryableName);
+    const controller = await registry.getController(tableName);
 
     expect(controller).to.eql(controllerAddress);
   });
 
-  // TODO: how do we lock controller in the new SDK?
-  it.skip("lock controller returns a transaction hash", async function () {
+  it("lock controller returns a transaction hash", async function () {
     const signer = accounts[1];
-    const tableland = getConnection(signer);
+    const db = getDatabase(signer);
+    const registry = getRegistry(signer);
 
-    const { meta: createMetadata } = await tableland
+    const { meta: createMetadata } = await db
       .prepare("CREATE TABLE test_create_lockcontroller (keyy TEXT, val TEXT);")
       .run();
-    const queryableName = createMetadata.txn?.name ?? "";
+    const tableName = createMetadata.txn?.name ?? "";
 
     // Hardhat #7
     const controllerAddress = "0x14dC79964da2C08b23698B3D3cc7Ca32193d9955";
 
-    const { hash } = await tableland.setController(
-      controllerAddress,
-      queryableName
-    );
+    const { hash } = await registry.setController({
+      controller: controllerAddress,
+      tableName,
+    });
 
     expect(typeof hash).to.eql("string");
     expect(hash.length).to.eql(66);
 
-    const tx = await tableland.lockController(queryableName);
+    const tx = await registry.lockController(tableName);
 
     expect(typeof tx.hash).to.eql("string");
   });
 
-  // TODO: how do we get a schema in the new SDK?
-  it.skip("get the schema for a table", async function () {
+  it("get the schema for a table", async function () {
     const signer = accounts[1];
-    const tableland = getConnection(signer);
+    const db = getDatabase(signer);
+    const validator = getValidator();
 
-    const { meta: createMetadata } = await tableland
+    const { meta: createMetadata } = await db
       .prepare("CREATE TABLE test_get_schema (keyy TEXT, val TEXT);")
       .run();
-    const queryableName = createMetadata.txn?.name ?? "";
+    const tableId = createMetadata.txn?.tableId ?? "";
+    const tableName = createMetadata.txn?.name ?? "";
 
-    const tableSchema = await tableland.schema(queryableName);
+    const table = await validator.getTableById({
+      chainId: localTablelandChainId,
+      tableId,
+    });
 
-    expect(typeof tableSchema.columns).to.eql("object");
-    expect(Array.isArray(tableSchema.table_constraints)).to.eql(true);
-    expect(tableSchema.columns.length).to.eql(1);
-    expect(tableSchema.columns[0].name).to.eql("a");
-    expect(tableSchema.columns[0].type).to.eql("int");
-    expect(Array.isArray(tableSchema.columns[0].constraints)).to.eql(true);
-    expect(tableSchema.columns[0].constraints[0].toLowerCase()).to.eql(
-      "primary key"
-    );
-  });
-
-  // TODO: how do we get the structure hash in the new SDK? I think this feature is gone -JW
-  it.skip("get the structure for a hash", async function () {
-    const signer = accounts[1];
-    const tableland = getConnection(signer);
-
-    const createStatement =
-      "CREATE TABLE test_get_structure (keyy TEXT, val TEXT);";
-    const { meta: createMetadata } = await tableland
-      .prepare(createStatement)
-      .run();
-    const queryableName = createMetadata.txn?.name ?? "";
-
-    const { structureHash } = await tableland.hash(createStatement);
-
-    const tableStructure = await tableland.structure(structureHash);
-
-    expect(Array.isArray(tableStructure)).to.eql(true);
-
-    const lastStructure = tableStructure[tableStructure.length - 1];
-
-    expect(lastStructure.name).to.eql(queryableName);
-    expect(lastStructure.controller).to.eql(accounts[1].address);
-    expect(lastStructure.structure).to.eql(structureHash);
+    expect(Array.isArray(table.schema.columns)).to.eql(true);
+    expect(table.schema.columns.length).to.eql(2);
+    expect(table.schema.columns[0]).to.eql({
+      name: "keyy",
+      type: "text",
+    });
+    expect(table.schema.columns[1]).to.eql({
+      name: "val",
+      type: "text",
+    });
+    expect(table.name).to.eql(tableName);
   });
 
   it("A write that violates table constraints throws error", async function () {
     const signer = accounts[1];
-    const tableland = getConnection(signer);
+    const db = getDatabase(signer);
 
-    const { meta: createMetadata } = await tableland
+    const { meta: createMetadata } = await db
       .prepare(
         "CREATE TABLE test_create_tc_violation (id TEXT, name TEXT, PRIMARY KEY(id));"
       )
@@ -441,7 +410,7 @@ describe("Validator, Chain, and SDK work end to end", function () {
 
     await expect(
       (async function () {
-        await tableland
+        await db
           .prepare(`INSERT INTO ${queryableName} VALUES (1, '1'), (1, '1')`)
           .all();
       })()


### PR DESCRIPTION
fixes #74

Here are the need updates to make use of the v4 sdk and evm packages.  
The majority of this is updating the tests to use the new sdk.
This also includes the removal of the getConnection function. In it's place we now have getDatabase, getRegistry, and getValidator.  These return default instances of their respective sdk interfaces that can be used with local-tableland.
Additionally there's a small fix to correctly shutdown the validator when it's being run via docker.