### PR TITLE
Include 4.0.0-pre.5 pre-release of sdk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@tableland/sdk": "^4.0.0-pre.3",
+        "@tableland/sdk": "^4.0.0-pre.5",
         "@tableland/validator": "^1.0.0",
         "cross-spawn": "^7.0.3",
         "enquirer": "^2.3.6",
@@ -1575,20 +1575,19 @@
       }
     },
     "node_modules/@tableland/sdk": {
-      "version": "4.0.0-pre.4",
-      "resolved": "https://registry.npmjs.org/@tableland/sdk/-/sdk-4.0.0-pre.4.tgz",
-      "integrity": "sha512-X+ABuuDKQZkPjA1N81pPv1pQmN1J8kSMmv8wk2+aikW7oMNf37IrJ0c9sektlhLP4WEkNK0WFzjJxIVP8/OLrA==",
+      "version": "4.0.0-pre.5",
+      "resolved": "https://registry.npmjs.org/@tableland/sdk/-/sdk-4.0.0-pre.5.tgz",
+      "integrity": "sha512-eYqmupsymY5wIPKmujye5aPRBvRZK88UrwPAXqONqseAJvzrgkoyXfL05WxRhSXHu5CGj43l+KAlmbDTfe3teQ==",
       "dependencies": {
         "@tableland/evm": "^4.0.0-pre.3",
-        "@tableland/sqlparser": "^1.0.0",
-        "camelize-ts": "^2.2.0",
+        "@tableland/sqlparser": "^1.0.2",
         "ethers": "^5.7.2"
       }
     },
     "node_modules/@tableland/sqlparser": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@tableland/sqlparser/-/sqlparser-1.0.0.tgz",
-      "integrity": "sha512-RlalXZHXuKKF+kzN1t/oESWXmXyzHHT6SICwZbSanNS2onlivcspoHzp/2CObLGNR50eGKZTzqYhqSFrizOrjw=="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@tableland/sqlparser/-/sqlparser-1.0.2.tgz",
+      "integrity": "sha512-K9A+RskPsl9ThrGWD8t7lUt3POsgUxHe6DXIk7yzx+3+gywKewGZh+0lYT9LJkhThrk6qm3JOyjxQyCAK2irbA=="
     },
     "node_modules/@tableland/validator": {
       "version": "1.0.0",
@@ -1889,23 +1888,6 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
-    "node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.48.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.48.2.tgz",
-      "integrity": "sha512-zEUFfonQid5KRDKoI3O+uP1GnrFd4tIHlvs+sTJXiWuypUWMuDaottkJuR612wQfOkjYbsaskSIURV9xo4f+Fw==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/types": "5.48.2",
-        "@typescript-eslint/visitor-keys": "5.48.2"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
     "node_modules/@typescript-eslint/type-utils": {
       "version": "5.49.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.49.0.tgz",
@@ -1988,46 +1970,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/types": {
-      "version": "5.48.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.48.2.tgz",
-      "integrity": "sha512-hE7dA77xxu7ByBc6KCzikgfRyBCTst6dZQpwaTy25iMYOnbNljDT4hjhrGEJJ0QoMjrfqrx+j1l1B9/LtKeuqA==",
-      "dev": true,
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.48.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.48.2.tgz",
-      "integrity": "sha512-bibvD3z6ilnoVxUBFEgkO0k0aFvUc4Cttt0dAreEr+nrAHhWzkO83PEVVuieK3DqcgL6VAK5dkzK8XUVja5Zcg==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/types": "5.48.2",
-        "@typescript-eslint/visitor-keys": "5.48.2",
-        "debug": "^4.3.4",
-        "globby": "^11.1.0",
-        "is-glob": "^4.0.3",
-        "semver": "^7.3.7",
-        "tsutils": "^3.21.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
       }
     },
     "node_modules/@typescript-eslint/utils": {
@@ -2120,23 +2062,6 @@
       "dev": true,
       "dependencies": {
         "@typescript-eslint/types": "5.49.0",
-        "eslint-visitor-keys": "^3.3.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.48.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.48.2.tgz",
-      "integrity": "sha512-z9njZLSkwmjFWUelGEwEbdf4NwKvfHxvGC0OcGN1Hp/XNDIcJ7D5DpPNPv6x6/mFvc1tQHsaWmpD/a4gOvvCJQ==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/types": "5.48.2",
         "eslint-visitor-keys": "^3.3.0"
       },
       "engines": {
@@ -2689,14 +2614,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/camelize-ts": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/camelize-ts/-/camelize-ts-2.2.0.tgz",
-      "integrity": "sha512-6jMy83qFmNrJIMQXXU6Bi7VVkyl/nBVvoxcVsGRDA6R01pPZpnO/LaIcx6dijJjHbBA2G0uHY4Irk7LeA274NQ==",
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
     "node_modules/catering": {
@@ -8011,20 +7928,19 @@
       "integrity": "sha512-cHwA+sqwpgErAQUy3Zc4YfYCztXKHPDGw3i/3ynXtFYyZgbtEsfeyCsVVPeCkqifp1vH+1P+rQQTSSGsIH/IKQ=="
     },
     "@tableland/sdk": {
-      "version": "4.0.0-pre.4",
-      "resolved": "https://registry.npmjs.org/@tableland/sdk/-/sdk-4.0.0-pre.4.tgz",
-      "integrity": "sha512-X+ABuuDKQZkPjA1N81pPv1pQmN1J8kSMmv8wk2+aikW7oMNf37IrJ0c9sektlhLP4WEkNK0WFzjJxIVP8/OLrA==",
+      "version": "4.0.0-pre.5",
+      "resolved": "https://registry.npmjs.org/@tableland/sdk/-/sdk-4.0.0-pre.5.tgz",
+      "integrity": "sha512-eYqmupsymY5wIPKmujye5aPRBvRZK88UrwPAXqONqseAJvzrgkoyXfL05WxRhSXHu5CGj43l+KAlmbDTfe3teQ==",
       "requires": {
         "@tableland/evm": "^4.0.0-pre.3",
-        "@tableland/sqlparser": "^1.0.0",
-        "camelize-ts": "^2.2.0",
+        "@tableland/sqlparser": "^1.0.2",
         "ethers": "^5.7.2"
       }
     },
     "@tableland/sqlparser": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@tableland/sqlparser/-/sqlparser-1.0.0.tgz",
-      "integrity": "sha512-RlalXZHXuKKF+kzN1t/oESWXmXyzHHT6SICwZbSanNS2onlivcspoHzp/2CObLGNR50eGKZTzqYhqSFrizOrjw=="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@tableland/sqlparser/-/sqlparser-1.0.2.tgz",
+      "integrity": "sha512-K9A+RskPsl9ThrGWD8t7lUt3POsgUxHe6DXIk7yzx+3+gywKewGZh+0lYT9LJkhThrk6qm3JOyjxQyCAK2irbA=="
     },
     "@tableland/validator": {
       "version": "1.0.0",
@@ -8244,16 +8160,6 @@
         }
       }
     },
-    "@typescript-eslint/scope-manager": {
-      "version": "5.48.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.48.2.tgz",
-      "integrity": "sha512-zEUFfonQid5KRDKoI3O+uP1GnrFd4tIHlvs+sTJXiWuypUWMuDaottkJuR612wQfOkjYbsaskSIURV9xo4f+Fw==",
-      "dev": true,
-      "requires": {
-        "@typescript-eslint/types": "5.48.2",
-        "@typescript-eslint/visitor-keys": "5.48.2"
-      }
-    },
     "@typescript-eslint/type-utils": {
       "version": "5.49.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.49.0.tgz",
@@ -8297,27 +8203,6 @@
             "eslint-visitor-keys": "^3.3.0"
           }
         }
-      }
-    },
-    "@typescript-eslint/types": {
-      "version": "5.48.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.48.2.tgz",
-      "integrity": "sha512-hE7dA77xxu7ByBc6KCzikgfRyBCTst6dZQpwaTy25iMYOnbNljDT4hjhrGEJJ0QoMjrfqrx+j1l1B9/LtKeuqA==",
-      "dev": true
-    },
-    "@typescript-eslint/typescript-estree": {
-      "version": "5.48.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.48.2.tgz",
-      "integrity": "sha512-bibvD3z6ilnoVxUBFEgkO0k0aFvUc4Cttt0dAreEr+nrAHhWzkO83PEVVuieK3DqcgL6VAK5dkzK8XUVja5Zcg==",
-      "dev": true,
-      "requires": {
-        "@typescript-eslint/types": "5.48.2",
-        "@typescript-eslint/visitor-keys": "5.48.2",
-        "debug": "^4.3.4",
-        "globby": "^11.1.0",
-        "is-glob": "^4.0.3",
-        "semver": "^7.3.7",
-        "tsutils": "^3.21.0"
       }
     },
     "@typescript-eslint/utils": {
@@ -8377,16 +8262,6 @@
             "eslint-visitor-keys": "^3.3.0"
           }
         }
-      }
-    },
-    "@typescript-eslint/visitor-keys": {
-      "version": "5.48.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.48.2.tgz",
-      "integrity": "sha512-z9njZLSkwmjFWUelGEwEbdf4NwKvfHxvGC0OcGN1Hp/XNDIcJ7D5DpPNPv6x6/mFvc1tQHsaWmpD/a4gOvvCJQ==",
-      "dev": true,
-      "requires": {
-        "@typescript-eslint/types": "5.48.2",
-        "eslint-visitor-keys": "^3.3.0"
       }
     },
     "abort-controller": {
@@ -8792,11 +8667,6 @@
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
       "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
       "dev": true
-    },
-    "camelize-ts": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/camelize-ts/-/camelize-ts-2.2.0.tgz",
-      "integrity": "sha512-6jMy83qFmNrJIMQXXU6Bi7VVkyl/nBVvoxcVsGRDA6R01pPZpnO/LaIcx6dijJjHbBA2G0uHY4Irk7LeA274NQ=="
     },
     "catering": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "local-tableland": "dist/esm/up.js"
   },
   "dependencies": {
-    "@tableland/sdk": "^4.0.0-pre.3",
+    "@tableland/sdk": "^4.0.0-pre.5",
     "@tableland/validator": "^1.0.0",
     "cross-spawn": "^7.0.3",
     "enquirer": "^2.3.6",

--- a/registry/package-lock.json
+++ b/registry/package-lock.json
@@ -10,7 +10,7 @@
         "@nomiclabs/hardhat-ethers": "^2.2.0",
         "@openzeppelin/contracts-upgradeable": "^4.8.0-rc.1",
         "@openzeppelin/hardhat-upgrades": "^1.21.0",
-        "@tableland/evm": "^4.0.0-pre.2",
+        "@tableland/evm": "^4.0.0",
         "erc721a-upgradeable": "^4.2.2",
         "hardhat": "^2.12.0"
       }
@@ -1602,9 +1602,9 @@
       }
     },
     "node_modules/@tableland/evm": {
-      "version": "4.0.0-pre.2",
-      "resolved": "https://registry.npmjs.org/@tableland/evm/-/evm-4.0.0-pre.2.tgz",
-      "integrity": "sha512-Cx+eVlovLvvUFkudlzBAMHh81J6LIuCNwDujNty+wgnpmkGJ/CJSP/gGe8VV/nchWyWkG3jPBaGRPa6Qi4xK2g==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@tableland/evm/-/evm-4.0.0.tgz",
+      "integrity": "sha512-HftJLfg2x2R/f6l6PasrQ73Za071+2T6vmJV+p5PwPtXjlb5Pl+V7rtNWAIZgWE8cQY14lWUyhzw4P/+rrEcGA==",
       "engines": {
         "node": ">=14.0.0"
       }
@@ -9479,9 +9479,9 @@
       }
     },
     "@tableland/evm": {
-      "version": "4.0.0-pre.2",
-      "resolved": "https://registry.npmjs.org/@tableland/evm/-/evm-4.0.0-pre.2.tgz",
-      "integrity": "sha512-Cx+eVlovLvvUFkudlzBAMHh81J6LIuCNwDujNty+wgnpmkGJ/CJSP/gGe8VV/nchWyWkG3jPBaGRPa6Qi4xK2g=="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@tableland/evm/-/evm-4.0.0.tgz",
+      "integrity": "sha512-HftJLfg2x2R/f6l6PasrQ73Za071+2T6vmJV+p5PwPtXjlb5Pl+V7rtNWAIZgWE8cQY14lWUyhzw4P/+rrEcGA=="
     },
     "@tsconfig/node10": {
       "version": "1.0.9",

--- a/registry/package.json
+++ b/registry/package.json
@@ -5,7 +5,7 @@
     "@nomiclabs/hardhat-ethers": "^2.2.0",
     "@openzeppelin/contracts-upgradeable": "^4.8.0-rc.1",
     "@openzeppelin/hardhat-upgrades": "^1.21.0",
-    "@tableland/evm": "^4.0.0-pre.2",
+    "@tableland/evm": "^4.0.0",
     "erc721a-upgradeable": "^4.2.2",
     "hardhat": "^2.12.0"
   }

--- a/src/util.ts
+++ b/src/util.ts
@@ -4,19 +4,16 @@ import { EventEmitter } from "node:events";
 import { Readable } from "node:stream";
 import { ChildProcess, SpawnSyncReturns } from "node:child_process";
 import { getDefaultProvider, Wallet } from "ethers";
-import {
-  getBaseUrl,
-  Database,
-  Registry,
-  Validator,
-  overrideDefaults,
-  getChainId,
-} from "@tableland/sdk";
+import { helpers, Database, Registry, Validator } from "@tableland/sdk";
 import { chalk } from "./chalk.js";
 
 // NOTE: We are creating this file in the prebuild.sh script so that we can support cjs and esm
 import { getDirname } from "./get-dirname.js";
 const _dirname = getDirname();
+
+const getBaseUrl = helpers.getBaseUrl;
+const overrideDefaults = helpers.overrideDefaults;
+const getChainId = helpers.getChainId;
 
 // The SDK does not know about the local-tableland contract
 overrideDefaults(getChainId("local-tableland"), {


### PR DESCRIPTION
This includes the newest pre-release of the sdk which includes changes to the helper function exports and a fix to the wasm-sqlparser.

We will need to get this fix into a pre-release of this package to fix downstream issues like https://github.com/tablelandnetwork/evm-tableland/actions/runs/4001002713/jobs/6866781001