### PR TITLE
Export `getRegistry` and `getValidator` helpers

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -16,6 +16,8 @@ import {
   waitForReady,
   getAccounts,
   getDatabase,
+  getRegistry,
+  getValidator,
   logSync,
   isWindows,
   inDebugMode,
@@ -231,5 +233,5 @@ class LocalTableland {
   }
 }
 
-export { LocalTableland, getAccounts, getDatabase };
+export { LocalTableland, getAccounts, getDatabase, getRegistry, getValidator };
 export type { Config };


### PR DESCRIPTION
In order to more easily leverage the new APIs in the SDK we can make the `getRegistry` and `getValidator` helpers available.