### PR TITLE
change `npm run up` to use default network setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     "build:esm": "cp src/get-dirname-esm.ts src/get-dirname.ts && tsc -p tsconfig.json",
     "build:cjs": "cp src/get-dirname-cjs.ts src/get-dirname.ts && tsc -p tsconfig.cjs.json",
     "build": "npm run clean && npm run build:esm && npm run build:cjs && ./fixup.sh",
-    "up": "node dist/esm/up.js --validator ../go-tableland --registry ../evm-tableland"
+    "up": "node dist/esm/up.js",
+    "up:dev": "node dist/esm/up.js --validator ../go-tableland --registry ../evm-tableland"
   },
   "bin": {
     "local-tableland": "dist/esm/up.js"


### PR DESCRIPTION
The `npm run up` command is currently running a network with docker and the locally available evm-tableland and go-tableland repositories.  This useful if you are working on a protocol change that spans serveral network components, but not the most common use of local tableland.
This changes to the `up` script to start a network with the default validator and registry, and adds an `up:dev` script to run local tableland with docker etc...