### PR TITLE
Placeholder for npm `next` version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "MIT",
       "dependencies": {
         "@tableland/sdk": "^4.0.0-pre.5",
-        "@tableland/validator": "^1.0.0",
+        "@tableland/validator": "^1.0.1-beta-6",
         "cross-spawn": "^7.0.3",
         "enquirer": "^2.3.6",
         "ethers": "^5.7.2",
@@ -1623,9 +1623,9 @@
       "integrity": "sha512-T9EieFjxLb9327nF5HhL5/bYBt7GFL3CgzxJeyU3tjGaQdi/0FQi6/z/jv3jG9pXkAed65lmntHNSHDhkUPjOQ=="
     },
     "node_modules/@tableland/validator": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@tableland/validator/-/validator-1.0.0.tgz",
-      "integrity": "sha512-ZzryZ+oIE/eOWLRpZrkmws26tJcssKW8RTfAIJ1nsLF6uTM7M4WDSXCVvTvXwnjk4fpPk+F6OiAUG9hSLmupmQ=="
+      "version": "1.0.1-beta-6",
+      "resolved": "https://registry.npmjs.org/@tableland/validator/-/validator-1.0.1-beta-6.tgz",
+      "integrity": "sha512-gdxj40p/4ADG8nuZfmzHllt5FjvbUEHSiUgJ4IELo1IDN4G3kq76cIwh0BZ8nM61wyDs9pWTwtnDDuL0GFun2w=="
     },
     "node_modules/@types/async-eventemitter": {
       "version": "0.2.1",
@@ -7823,9 +7823,9 @@
       "integrity": "sha512-T9EieFjxLb9327nF5HhL5/bYBt7GFL3CgzxJeyU3tjGaQdi/0FQi6/z/jv3jG9pXkAed65lmntHNSHDhkUPjOQ=="
     },
     "@tableland/validator": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@tableland/validator/-/validator-1.0.0.tgz",
-      "integrity": "sha512-ZzryZ+oIE/eOWLRpZrkmws26tJcssKW8RTfAIJ1nsLF6uTM7M4WDSXCVvTvXwnjk4fpPk+F6OiAUG9hSLmupmQ=="
+      "version": "1.0.1-beta-6",
+      "resolved": "https://registry.npmjs.org/@tableland/validator/-/validator-1.0.1-beta-6.tgz",
+      "integrity": "sha512-gdxj40p/4ADG8nuZfmzHllt5FjvbUEHSiUgJ4IELo1IDN4G3kq76cIwh0BZ8nM61wyDs9pWTwtnDDuL0GFun2w=="
     },
     "@types/async-eventemitter": {
       "version": "0.2.1",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   },
   "dependencies": {
     "@tableland/sdk": "^4.0.0-pre.5",
-    "@tableland/validator": "^1.0.0",
+    "@tableland/validator": "^1.0.1-beta-6",
     "cross-spawn": "^7.0.3",
     "enquirer": "^2.3.6",
     "ethers": "^5.7.2",


### PR DESCRIPTION
@carsonfarmer There's a fix in the Validator's current pre-release for "fix: read query validation not considering compound select".  I thinking we could include it in this package and publish it as `next` on npm.  Does that makes sense to you?
If so, I'm thinking we can leave this in draft and run the publish workflow with this branch as the target and wait to merge this until the Validator does an official release.