### PR TITLE
update tableland dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@tableland/sdk": "^4.0.0-pre.5",
-        "@tableland/validator": "^1.0.0",
+        "@tableland/sdk": "^4.0.2",
+        "@tableland/validator": "^1.1.0",
         "cross-spawn": "^7.0.3",
         "enquirer": "^2.3.6",
         "ethers": "^5.7.2",
@@ -1600,32 +1600,32 @@
       }
     },
     "node_modules/@tableland/evm": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@tableland/evm/-/evm-4.0.0.tgz",
-      "integrity": "sha512-HftJLfg2x2R/f6l6PasrQ73Za071+2T6vmJV+p5PwPtXjlb5Pl+V7rtNWAIZgWE8cQY14lWUyhzw4P/+rrEcGA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@tableland/evm/-/evm-4.1.0.tgz",
+      "integrity": "sha512-1/qIewZo5//2egVxZwjZyo8TySDGzlF8swdxMjvPeVVx9OJprT8ttF8nJmMtKIBNK0b4HkvW/qA2AqP8cOGcQg==",
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@tableland/sdk": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@tableland/sdk/-/sdk-4.0.1.tgz",
-      "integrity": "sha512-ScVsLS/da0xtLUwBx0pd9+5SLgdpMYwFPfL3CYidkRnO37Jikx2Z1pmkeT6JMawTovo/t3pKuN8RBxLigxxQpQ==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@tableland/sdk/-/sdk-4.0.2.tgz",
+      "integrity": "sha512-3Tpoiff6kfq2CzKx/7LUcFpydBfCvkOIvpaMbyjz0b7HVVsMFA2uj6CaevPYV1uP/W7Ncn/ytXwys5MtMp9SNw==",
       "dependencies": {
-        "@tableland/evm": "^4.0.0",
-        "@tableland/sqlparser": "^1.0.4",
+        "@tableland/evm": "^4.1.0",
+        "@tableland/sqlparser": "^1.0.5",
         "ethers": "^5.7.2"
       }
     },
     "node_modules/@tableland/sqlparser": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@tableland/sqlparser/-/sqlparser-1.0.4.tgz",
-      "integrity": "sha512-T9EieFjxLb9327nF5HhL5/bYBt7GFL3CgzxJeyU3tjGaQdi/0FQi6/z/jv3jG9pXkAed65lmntHNSHDhkUPjOQ=="
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@tableland/sqlparser/-/sqlparser-1.0.5.tgz",
+      "integrity": "sha512-dotXZulYNKdxLNbGkenQGAjuQfuXFRcxUqtt8ffyoNG3n6llUVOnTVXWjcSL0B36kMSVul7XpfKSQkGOa13awg=="
     },
     "node_modules/@tableland/validator": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@tableland/validator/-/validator-1.0.0.tgz",
-      "integrity": "sha512-ZzryZ+oIE/eOWLRpZrkmws26tJcssKW8RTfAIJ1nsLF6uTM7M4WDSXCVvTvXwnjk4fpPk+F6OiAUG9hSLmupmQ=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@tableland/validator/-/validator-1.1.0.tgz",
+      "integrity": "sha512-eaz8C5k4kQa8NLxrYM17i778bFbw124iTKgwnJhBbkRTQ0+KOcq2tUWAgzCk5pmpGZz5Tfy40sD7UcbfRDlDfg=="
     },
     "node_modules/@types/async-eventemitter": {
       "version": "0.2.1",
@@ -7981,29 +7981,29 @@
       }
     },
     "@tableland/evm": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@tableland/evm/-/evm-4.0.0.tgz",
-      "integrity": "sha512-HftJLfg2x2R/f6l6PasrQ73Za071+2T6vmJV+p5PwPtXjlb5Pl+V7rtNWAIZgWE8cQY14lWUyhzw4P/+rrEcGA=="
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@tableland/evm/-/evm-4.1.0.tgz",
+      "integrity": "sha512-1/qIewZo5//2egVxZwjZyo8TySDGzlF8swdxMjvPeVVx9OJprT8ttF8nJmMtKIBNK0b4HkvW/qA2AqP8cOGcQg=="
     },
     "@tableland/sdk": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@tableland/sdk/-/sdk-4.0.1.tgz",
-      "integrity": "sha512-ScVsLS/da0xtLUwBx0pd9+5SLgdpMYwFPfL3CYidkRnO37Jikx2Z1pmkeT6JMawTovo/t3pKuN8RBxLigxxQpQ==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@tableland/sdk/-/sdk-4.0.2.tgz",
+      "integrity": "sha512-3Tpoiff6kfq2CzKx/7LUcFpydBfCvkOIvpaMbyjz0b7HVVsMFA2uj6CaevPYV1uP/W7Ncn/ytXwys5MtMp9SNw==",
       "requires": {
-        "@tableland/evm": "^4.0.0",
-        "@tableland/sqlparser": "^1.0.4",
+        "@tableland/evm": "^4.1.0",
+        "@tableland/sqlparser": "^1.0.5",
         "ethers": "^5.7.2"
       }
     },
     "@tableland/sqlparser": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@tableland/sqlparser/-/sqlparser-1.0.4.tgz",
-      "integrity": "sha512-T9EieFjxLb9327nF5HhL5/bYBt7GFL3CgzxJeyU3tjGaQdi/0FQi6/z/jv3jG9pXkAed65lmntHNSHDhkUPjOQ=="
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@tableland/sqlparser/-/sqlparser-1.0.5.tgz",
+      "integrity": "sha512-dotXZulYNKdxLNbGkenQGAjuQfuXFRcxUqtt8ffyoNG3n6llUVOnTVXWjcSL0B36kMSVul7XpfKSQkGOa13awg=="
     },
     "@tableland/validator": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@tableland/validator/-/validator-1.0.0.tgz",
-      "integrity": "sha512-ZzryZ+oIE/eOWLRpZrkmws26tJcssKW8RTfAIJ1nsLF6uTM7M4WDSXCVvTvXwnjk4fpPk+F6OiAUG9hSLmupmQ=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@tableland/validator/-/validator-1.1.0.tgz",
+      "integrity": "sha512-eaz8C5k4kQa8NLxrYM17i778bFbw124iTKgwnJhBbkRTQ0+KOcq2tUWAgzCk5pmpGZz5Tfy40sD7UcbfRDlDfg=="
     },
     "@types/async-eventemitter": {
       "version": "0.2.1",

--- a/package.json
+++ b/package.json
@@ -56,8 +56,8 @@
     "local-tableland": "dist/esm/up.js"
   },
   "dependencies": {
-    "@tableland/sdk": "^4.0.0-pre.5",
-    "@tableland/validator": "^1.0.0",
+    "@tableland/sdk": "^4.0.2",
+    "@tableland/validator": "^1.1.0",
     "cross-spawn": "^7.0.3",
     "enquirer": "^2.3.6",
     "ethers": "^5.7.2",

--- a/registry/package-lock.json
+++ b/registry/package-lock.json
@@ -10,7 +10,7 @@
         "@nomiclabs/hardhat-ethers": "^2.2.0",
         "@openzeppelin/contracts-upgradeable": "^4.8.0-rc.1",
         "@openzeppelin/hardhat-upgrades": "^1.21.0",
-        "@tableland/evm": "^4.0.0",
+        "@tableland/evm": "^4.1.0",
         "erc721a-upgradeable": "^4.2.2",
         "hardhat": "^2.12.0"
       }
@@ -1602,9 +1602,9 @@
       }
     },
     "node_modules/@tableland/evm": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@tableland/evm/-/evm-4.0.0.tgz",
-      "integrity": "sha512-HftJLfg2x2R/f6l6PasrQ73Za071+2T6vmJV+p5PwPtXjlb5Pl+V7rtNWAIZgWE8cQY14lWUyhzw4P/+rrEcGA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@tableland/evm/-/evm-4.1.0.tgz",
+      "integrity": "sha512-1/qIewZo5//2egVxZwjZyo8TySDGzlF8swdxMjvPeVVx9OJprT8ttF8nJmMtKIBNK0b4HkvW/qA2AqP8cOGcQg==",
       "engines": {
         "node": ">=14.0.0"
       }
@@ -9479,9 +9479,9 @@
       }
     },
     "@tableland/evm": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@tableland/evm/-/evm-4.0.0.tgz",
-      "integrity": "sha512-HftJLfg2x2R/f6l6PasrQ73Za071+2T6vmJV+p5PwPtXjlb5Pl+V7rtNWAIZgWE8cQY14lWUyhzw4P/+rrEcGA=="
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@tableland/evm/-/evm-4.1.0.tgz",
+      "integrity": "sha512-1/qIewZo5//2egVxZwjZyo8TySDGzlF8swdxMjvPeVVx9OJprT8ttF8nJmMtKIBNK0b4HkvW/qA2AqP8cOGcQg=="
     },
     "@tsconfig/node10": {
       "version": "1.0.9",

--- a/registry/package.json
+++ b/registry/package.json
@@ -5,7 +5,7 @@
     "@nomiclabs/hardhat-ethers": "^2.2.0",
     "@openzeppelin/contracts-upgradeable": "^4.8.0-rc.1",
     "@openzeppelin/hardhat-upgrades": "^1.21.0",
-    "@tableland/evm": "^4.0.0",
+    "@tableland/evm": "^4.1.0",
     "erc721a-upgradeable": "^4.2.2",
     "hardhat": "^2.12.0"
   }


### PR DESCRIPTION
This updates all of the tableland package version after our ship today.  We should publish this change before our next ship. 