### PR TITLE
Fix registry dir README

### DIFF
--- a/registry/README.md
+++ b/registry/README.md
@@ -1,13 +1,3 @@
-# Sample Hardhat Project
+# Local only Tableland Registry Deployment helper
 
-This project demonstrates a basic Hardhat use case. It comes with a sample contract, a test for that contract, and a script that deploys that contract.
-
-Try running some of the following tasks:
-
-```shell
-npx hardhat help
-npx hardhat test
-REPORT_GAS=true npx hardhat test
-npx hardhat node
-npx hardhat run scripts/deploy.ts
-```
+This directory contains the needed tooling to deploy the Tableland Registry contract to a local only Tableland network via hardhat


### PR DESCRIPTION
The README in the registry directory was still the boilerplate hardhat README, which is not correct.