### PR TITLE
enable passing validator config to binary

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -35,6 +35,7 @@ class LocalTableland {
 
   validatorDir?: string;
   registryDir?: string;
+  docker?: boolean;
   verbose?: boolean;
   silent?: boolean;
 
@@ -56,6 +57,7 @@ class LocalTableland {
     } else {
       this.registryDir = await defaultRegistryDir();
     }
+    if (typeof config.docker === "boolean") this.docker = config.docker;
     if (typeof config.verbose === "boolean") this.verbose = config.verbose;
     if (typeof config.silent === "boolean") this.silent = config.silent;
 
@@ -120,7 +122,7 @@ class LocalTableland {
 
     // need to determine if we are starting the validator via docker
     // and a local repo, or if are running a binary etc...
-    const ValidatorClass = this.validatorDir ? ValidatorDev : ValidatorPkg;
+    const ValidatorClass = this.docker ? ValidatorDev : ValidatorPkg;
 
     this.validator = new ValidatorClass(this.validatorDir);
 

--- a/src/up.ts
+++ b/src/up.ts
@@ -9,19 +9,25 @@ import { projectBuilder } from "./project-builder.js";
 const argv = yargs(hideBin(process.argv)).options({
   validator: {
     type: "string",
-    description: "Path the the Tableland Validator repository",
+    description:
+      "Path the the Tableland Validator directory.  If docker flag is set this must be the full repository.",
   },
   registry: {
     type: "string",
-    description: "Path the the Tableland Registry contract repository",
+    description: "Path the the Tableland Registry contract repository.",
+  },
+  docker: {
+    type: "boolean",
+    default: false,
+    description: "Use Docker to run the Validator.",
   },
   verbose: {
     type: "boolean",
-    description: "Output verbose logs to stdout",
+    description: "Output verbose logs to stdout.",
   },
   silent: {
     type: "boolean",
-    description: "Silence all output to stdout",
+    description: "Silence all output to stdout.",
   },
   init: {
     type: "boolean",
@@ -46,6 +52,7 @@ const go = async function () {
 
   if (tsArgv.validator) opts.validator = tsArgv.validator;
   if (tsArgv.registry) opts.registry = tsArgv.registry;
+  if (tsArgv.docker) opts.docker = tsArgv.docker;
   if (typeof tsArgv.verbose === "boolean") opts.verbose = tsArgv.verbose;
   if (typeof tsArgv.silent === "boolean") opts.silent = tsArgv.silent;
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -22,9 +22,9 @@ overrideDefaults(getChainId("local-tableland"), {
 
 export type ConfigDescriptor = {
   name: string;
-  env: "VALIDATOR_DIR" | "REGISTRY_DIR" | "VERBOSE" | "SILENT";
-  file: "validatorDir" | "registryDir" | "verbose" | "silent";
-  arg: "validator" | "registry" | "verbose" | "silent";
+  env: "VALIDATOR_DIR" | "REGISTRY_DIR" | "VERBOSE" | "SILENT" | "DOCKER";
+  file: "validatorDir" | "registryDir" | "verbose" | "silent" | "docker";
+  arg: "validator" | "registry" | "verbose" | "silent" | "docker";
   isPath: boolean;
 };
 
@@ -49,6 +49,13 @@ const configDescriptors: ConfigDescriptor[] = [
     isPath: true,
   },
   {
+    name: "docker",
+    env: "DOCKER",
+    file: "docker",
+    arg: "docker",
+    isPath: false,
+  },
+  {
     name: "verbose",
     env: "VERBOSE",
     file: "verbose",
@@ -69,6 +76,7 @@ export type Config = {
   validatorDir?: string;
   registry?: string;
   registryDir?: string;
+  docker?: boolean;
   verbose?: boolean;
   silent?: boolean;
 };

--- a/src/validators.ts
+++ b/src/validators.ts
@@ -20,6 +20,12 @@ class ValidatorPkg {
   process?: ChildProcess;
   validatorDir = resolve(_dirname, "..", "..", "validator");
 
+  constructor(validatorDir?: string) {
+    if (typeof validatorDir === "string") {
+      this.validatorDir = validatorDir;
+    }
+  }
+
   start() {
     const binPath = getBinPath();
     if (!binPath) {


### PR DESCRIPTION
This change allows users to specify a custom validator config when they are running the Validator via the binary.
Example usage: 
```sh
npm install @tableland/local@2.0.0-pre.0
npx local-tableland --validator <path to a directory holding your custom config>
```
Notice that the flag is the same as how you specify the validator config path when running L.T. via docker.  The path must be a directory that contains a `config.json` file which is a valid validator config file.  An example config exists [here](https://github.com/tablelandnetwork/local-tableland/blob/main/validator/config.json).  The directory will also be used to store the underlying validator database files while L.T. is running.

Before this change the use of docker vs. the binary was determined by the presence of the `--validator` flag.  Since this flag can now be used with the binary, another flag called `--docker` has been introduced which indicates if L.T. should be run via docker.  Because of this, this change will require a major version bump.